### PR TITLE
feat(api): add ORM models and initial migration

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,9 +1,9 @@
-# GridBoss API
+﻿# GridBoss API
 
-The API service is built with FastAPI and provides the backend for GridBoss. This directory currently ships a development skeleton together with dependency and tooling configuration so future PBIs can focus on implementing business logic.
+The API service is built with FastAPI and provides the backend for GridBoss. The database layer now includes SQLAlchemy models, session helpers, and Alembic migrations for the core league management entities.
 
 ## Quick start
-1. Create a virtual environment (one is already generated as `.venv` when running automated setup):
+1. Create or reuse the virtual environment (one is already generated as `.venv` during setup):
    ```powershell
    python -m venv .venv
    ```
@@ -11,7 +11,12 @@ The API service is built with FastAPI and provides the backend for GridBoss. Thi
    ```powershell
    .venv\Scripts\pip install -r requirements-dev.txt
    ```
-3. Run the development server:
+3. Apply database migrations (requires PostgreSQL available at `DATABASE_URL`):
+   ```powershell
+   $env:DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5432/gridboss"
+   .venv\Scripts\alembic upgrade head
+   ```
+4. Run the development server:
    ```powershell
    .venv\Scripts\uvicorn --app app.main:app --reload
    ```
@@ -19,10 +24,16 @@ The API service is built with FastAPI and provides the backend for GridBoss. Thi
 ## Tooling
 - `black` and `ruff` are configured via `pyproject.toml` with a 100 character line length.
 - `pytest` is available for unit and integration tests.
-- Database and messaging dependencies follow versions aligned with the master spec (PostgreSQL via SQLAlchemy, Redis, psycopg, Alembic).
+- Core database models live in `app/db/models.py` and share the base in `app/db/base.py`.
+- Alembic configuration resides in `alembic.ini` with scripts under `app/db/migrations/`.
+
+## Database Modules
+- `app/db/session.py` exposes `get_session()` for FastAPI dependencies and caches the engine/sessionmaker.
+- `app/db/models.py` defines users, leagues, memberships, teams, drivers, seasons, events, points, results, Discord integrations, billing, and audit logs.
+- The initial migration (`versions/20250921_0001_initial_schema.py`) provisions all core tables, constraints, and indexes described in the master spec.
 
 ## Next steps
 Future PBIs will introduce:
-- Database models and session management.
 - Auth, RBAC, and API routes.
 - Background workers, Stripe integration, and Discord bot communication.
+- Automated tests and seed data.

--- a/api/alembic.ini
+++ b/api/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = app/db/migrations
+prepend_sys_path = .
+
+sqlalchemy.url = postgresql+psycopg://postgres:postgres@localhost:5432/gridboss
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/api/app/db/__init__.py
+++ b/api/app/db/__init__.py
@@ -1,0 +1,6 @@
+"""Database package exports."""
+
+from . import models  # noqa: F401 - ensure models are registered with metadata
+from .base import Base, metadata_obj
+
+__all__ = ["Base", "metadata_obj"]

--- a/api/app/db/base.py
+++ b/api/app/db/base.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase
+
+NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+metadata_obj = MetaData(naming_convention=NAMING_CONVENTION)
+
+
+class Base(DeclarativeBase):
+    metadata = metadata_obj

--- a/api/app/db/migrations/env.py
+++ b/api/app/db/migrations/env.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.db import (
+    Base,
+    models,  # noqa: F401 - ensure models register with Base
+)
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+DATABASE_URL = os.getenv("DATABASE_URL", config.get_main_option("sqlalchemy.url"))
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL environment variable must be set for Alembic migrations.")
+
+# Ensure alembic config uses the resolved URL
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    context.configure(url=DATABASE_URL, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/api/app/db/migrations/script.py.mako
+++ b/api/app/db/migrations/script.py.mako
@@ -1,0 +1,19 @@
+<%
+import sqlalchemy as sa
+from alembic import op
+%>
+
+"""${message}"""
+
+revision = ${repr(revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/api/app/db/migrations/versions/20250921_0001_initial_schema.py
+++ b/api/app/db/migrations/versions/20250921_0001_initial_schema.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20250921_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    league_role = sa.Enum("OWNER", "ADMIN", "STEWARD", "DRIVER", name="league_role")
+    league_role.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "users",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column("email", sa.String(), nullable=True),
+        sa.Column("discord_id", sa.String(), nullable=True),
+        sa.Column("discord_username", sa.String(), nullable=True),
+        sa.Column("avatar_url", sa.String(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_users"),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+        sa.UniqueConstraint("discord_id", name="uq_users_discord_id"),
+    )
+
+    op.create_table(
+        "leagues",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column("owner_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("slug", sa.String(), nullable=False),
+        sa.Column("plan", sa.String(), server_default=sa.text("'FREE'"), nullable=False),
+        sa.Column("driver_limit", sa.Integer(), server_default=sa.text("20"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["owner_id"], ["users.id"], name="fk_leagues_owner_id_users", ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_leagues"),
+        sa.UniqueConstraint("slug", name="uq_leagues_slug"),
+    )
+
+    op.create_table(
+        "memberships",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("league_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("role", sa.Enum(name="league_role"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["league_id"],
+            ["leagues.id"],
+            name="fk_memberships_league_id_leagues",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], name="fk_memberships_user_id_users", ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_memberships"),
+        sa.UniqueConstraint("league_id", "user_id", name="uq_memberships_league_user"),
+    )
+
+    op.create_table(
+        "teams",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("league_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["league_id"], ["leagues.id"], name="fk_teams_league_id_leagues", ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_teams"),
+        sa.UniqueConstraint("league_id", "name", name="uq_teams_league_name"),
+    )
+
+    op.create_table(
+        "drivers",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("league_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("display_name", sa.String(), nullable=False),
+        sa.Column("discord_id", sa.String(), nullable=True),
+        sa.Column("team_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["league_id"], ["leagues.id"], name="fk_drivers_league_id_leagues", ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["team_id"], ["teams.id"], name="fk_drivers_team_id_teams", ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], name="fk_drivers_user_id_users", ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_drivers"),
+        sa.UniqueConstraint("league_id", "display_name", name="uq_drivers_league_display"),
+    )
+
+    op.create_table(
+        "seasons",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("league_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["league_id"], ["leagues.id"], name="fk_seasons_league_id_leagues", ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_seasons"),
+    )
+
+    op.create_table(
+        "events",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("league_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("season_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("track", sa.String(), nullable=False),
+        sa.Column("start_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("laps", sa.Integer(), nullable=True),
+        sa.Column("distance_km", sa.Numeric(6, 2), nullable=True),
+        sa.Column("status", sa.String(), server_default=sa.text("'SCHEDULED'"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["league_id"], ["leagues.id"], name="fk_events_league_id_leagues", ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["season_id"], ["seasons.id"], name="fk_events_season_id_seasons", ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_events"),
+    )
+    op.create_index("ix_events_league_start_time", "events", ["league_id", "start_time"])
+    op.create_index(
+        "ix_events_status_scheduled",
+        "events",
+        ["status"],
+        postgresql_where=sa.text("status = 'SCHEDULED'"),
+    )
+
+    op.create_table(
+        "points_schemes",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("league_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("season_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("is_default", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["league_id"],
+            ["leagues.id"],
+            name="fk_points_schemes_league_id_leagues",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["season_id"],
+            ["seasons.id"],
+            name="fk_points_schemes_season_id_seasons",
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_points_schemes"),
+    )
+
+    op.create_table(
+        "points_rules",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("scheme_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("points", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["scheme_id"],
+            ["points_schemes.id"],
+            name="fk_points_rules_scheme_id_points_schemes",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_points_rules"),
+    )
+
+    op.create_table(
+        "results",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("event_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("driver_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("finish_position", sa.Integer(), nullable=False),
+        sa.Column("started_position", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(), server_default=sa.text("'FINISHED'"), nullable=False),
+        sa.Column("bonus_points", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("penalty_points", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("total_points", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["driver_id"], ["drivers.id"], name="fk_results_driver_id_drivers", ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["event_id"], ["events.id"], name="fk_results_event_id_events", ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_results"),
+        sa.UniqueConstraint("event_id", "driver_id", name="uq_results_event_driver"),
+    )
+    op.create_index("ix_results_event_finish", "results", ["event_id", "finish_position"])
+
+    op.create_table(
+        "integrations_discord",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("league_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("guild_id", sa.String(), nullable=False),
+        sa.Column("channel_id", sa.String(), nullable=True),
+        sa.Column("installed_by_user", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["installed_by_user"],
+            ["users.id"],
+            name="fk_integrations_discord_installed_by_user_users",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["league_id"],
+            ["leagues.id"],
+            name="fk_integrations_discord_league_id_leagues",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_integrations_discord"),
+        sa.UniqueConstraint("league_id", "guild_id", name="uq_integrations_discord_guild"),
+    )
+
+    op.create_table(
+        "billing_accounts",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("owner_user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("stripe_customer_id", sa.String(), nullable=True),
+        sa.Column("plan", sa.String(), server_default=sa.text("'FREE'"), nullable=False),
+        sa.Column("current_period_end", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["owner_user_id"],
+            ["users.id"],
+            name="fk_billing_accounts_owner_user_id_users",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_billing_accounts"),
+        sa.UniqueConstraint("stripe_customer_id", name="uq_billing_accounts_stripe_customer_id"),
+    )
+
+    op.create_table(
+        "subscriptions",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("billing_account_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("stripe_subscription_id", sa.String(), nullable=True),
+        sa.Column("plan", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column(
+            "started_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["billing_account_id"],
+            ["billing_accounts.id"],
+            name="fk_subscriptions_billing_account_id_billing_accounts",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_subscriptions"),
+        sa.UniqueConstraint(
+            "stripe_subscription_id", name="uq_subscriptions_stripe_subscription_id"
+        ),
+    )
+
+    op.create_table(
+        "audit_logs",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "timestamp", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column("actor_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("league_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("entity", sa.String(), nullable=False),
+        sa.Column("entity_id", sa.String(), nullable=True),
+        sa.Column("action", sa.String(), nullable=False),
+        sa.Column("before_state", sa.JSON(), nullable=True),
+        sa.Column("after_state", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["actor_id"], ["users.id"], name="fk_audit_logs_actor_id_users", ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["league_id"],
+            ["leagues.id"],
+            name="fk_audit_logs_league_id_leagues",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_audit_logs"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("audit_logs")
+    op.drop_table("subscriptions")
+    op.drop_table("billing_accounts")
+    op.drop_table("integrations_discord")
+    op.drop_index("ix_results_event_finish", table_name="results")
+    op.drop_table("results")
+    op.drop_table("points_rules")
+    op.drop_table("points_schemes")
+    op.drop_index("ix_events_status_scheduled", table_name="events")
+    op.drop_index("ix_events_league_start_time", table_name="events")
+    op.drop_table("events")
+    op.drop_table("seasons")
+    op.drop_table("drivers")
+    op.drop_table("teams")
+    op.drop_table("memberships")
+    op.drop_table("leagues")
+    op.drop_table("users")
+    league_role = sa.Enum(name="league_role")
+    league_role.drop(op.get_bind(), checkfirst=True)

--- a/api/app/db/models.py
+++ b/api/app/db/models.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class LeagueRole(enum.StrEnum):
+    OWNER = "OWNER"
+    ADMIN = "ADMIN"
+    STEWARD = "STEWARD"
+    DRIVER = "DRIVER"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    email: Mapped[str | None] = mapped_column(String, unique=True)
+    discord_id: Mapped[str | None] = mapped_column(String, unique=True)
+    discord_username: Mapped[str | None] = mapped_column(String)
+    avatar_url: Mapped[str | None] = mapped_column(String)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+
+    leagues_owned: Mapped[list[League]] = relationship(back_populates="owner")
+    memberships: Mapped[list[Membership]] = relationship(back_populates="user")
+    billing_account: Mapped[BillingAccount | None] = relationship(
+        back_populates="owner", uselist=False
+    )
+    drivers: Mapped[list[Driver]] = relationship(back_populates="user")
+    audit_logs: Mapped[list[AuditLog]] = relationship(back_populates="actor")
+
+
+class League(Base):
+    __tablename__ = "leagues"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    owner_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    slug: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    plan: Mapped[str] = mapped_column(String, nullable=False, server_default=text("'FREE'"))
+    driver_limit: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("20"))
+
+    owner: Mapped[User | None] = relationship(back_populates="leagues_owned")
+    memberships: Mapped[list[Membership]] = relationship(back_populates="league")
+    teams: Mapped[list[Team]] = relationship(back_populates="league")
+    drivers: Mapped[list[Driver]] = relationship(back_populates="league")
+    seasons: Mapped[list[Season]] = relationship(back_populates="league")
+    events: Mapped[list[Event]] = relationship(back_populates="league")
+    points_schemes: Mapped[list[PointsScheme]] = relationship(back_populates="league")
+    integrations: Mapped[list[DiscordIntegration]] = relationship(back_populates="league")
+    audit_logs: Mapped[list[AuditLog]] = relationship(back_populates="league")
+
+
+class Membership(Base):
+    __tablename__ = "memberships"
+    __table_args__ = (UniqueConstraint("league_id", "user_id", name="uq_memberships_league_user"),)
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    league_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("leagues.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    role: Mapped[LeagueRole] = mapped_column(
+        Enum(LeagueRole, name="league_role", validate_strings=True), nullable=False
+    )
+
+    league: Mapped[League] = relationship(back_populates="memberships")
+    user: Mapped[User] = relationship(back_populates="memberships")
+
+
+class Team(Base):
+    __tablename__ = "teams"
+    __table_args__ = (UniqueConstraint("league_id", "name", name="uq_teams_league_name"),)
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    league_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("leagues.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+
+    league: Mapped[League] = relationship(back_populates="teams")
+    drivers: Mapped[list[Driver]] = relationship(back_populates="team")
+
+
+class Driver(Base):
+    __tablename__ = "drivers"
+    __table_args__ = (
+        UniqueConstraint("league_id", "display_name", name="uq_drivers_league_display"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    league_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("leagues.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    display_name: Mapped[str] = mapped_column(String, nullable=False)
+    discord_id: Mapped[str | None] = mapped_column(String)
+    team_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+    )
+
+    league: Mapped[League] = relationship(back_populates="drivers")
+    user: Mapped[User | None] = relationship(back_populates="drivers")
+    team: Mapped[Team | None] = relationship(back_populates="drivers")
+    results: Mapped[list[Result]] = relationship(back_populates="driver")
+
+
+class Season(Base):
+    __tablename__ = "seasons"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    league_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("leagues.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+
+    league: Mapped[League] = relationship(back_populates="seasons")
+    events: Mapped[list[Event]] = relationship(back_populates="season")
+    points_schemes: Mapped[list[PointsScheme]] = relationship(back_populates="season")
+
+
+class EventStatus(enum.StrEnum):
+    SCHEDULED = "SCHEDULED"
+    COMPLETED = "COMPLETED"
+    CANCELED = "CANCELED"
+
+
+class Event(Base):
+    __tablename__ = "events"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    league_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("leagues.id", ondelete="CASCADE"), nullable=False
+    )
+    season_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("seasons.id", ondelete="SET NULL"), nullable=True
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    track: Mapped[str] = mapped_column(String, nullable=False)
+    start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    laps: Mapped[int | None] = mapped_column(Integer)
+    distance_km: Mapped[float | None] = mapped_column(Numeric(6, 2))
+    status: Mapped[str] = mapped_column(
+        String, nullable=False, server_default=text("'SCHEDULED'"), index=False
+    )
+
+    league: Mapped[League] = relationship(back_populates="events")
+    season: Mapped[Season | None] = relationship(back_populates="events")
+    results: Mapped[list[Result]] = relationship(back_populates="event")
+
+
+Index("ix_events_league_start_time", Event.league_id, Event.start_time)
+Index(
+    "ix_events_status_scheduled",
+    Event.status,
+    postgresql_where=Event.status == EventStatus.SCHEDULED.value,
+)
+
+
+class PointsScheme(Base):
+    __tablename__ = "points_schemes"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    league_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("leagues.id", ondelete="CASCADE"), nullable=False
+    )
+    season_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("seasons.id", ondelete="SET NULL"), nullable=True
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+
+    league: Mapped[League] = relationship(back_populates="points_schemes")
+    season: Mapped[Season | None] = relationship(back_populates="points_schemes")
+    rules: Mapped[list[PointsRule]] = relationship(
+        back_populates="scheme", cascade="all, delete-orphan"
+    )
+
+
+class PointsRule(Base):
+    __tablename__ = "points_rules"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    scheme_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("points_schemes.id", ondelete="CASCADE"), nullable=False
+    )
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    points: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    scheme: Mapped[PointsScheme] = relationship(back_populates="rules")
+
+
+class ResultStatus(enum.StrEnum):
+    FINISHED = "FINISHED"
+    DNF = "DNF"
+    DNS = "DNS"
+    DSQ = "DSQ"
+
+
+class Result(Base):
+    __tablename__ = "results"
+    __table_args__ = (UniqueConstraint("event_id", "driver_id", name="uq_results_event_driver"),)
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    event_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("events.id", ondelete="CASCADE"), nullable=False
+    )
+    driver_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("drivers.id", ondelete="CASCADE"), nullable=False
+    )
+    finish_position: Mapped[int] = mapped_column(Integer, nullable=False)
+    started_position: Mapped[int | None] = mapped_column(Integer)
+    status: Mapped[str] = mapped_column(
+        String, nullable=False, server_default=text("'FINISHED'"), index=False
+    )
+    bonus_points: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    penalty_points: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    total_points: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    event: Mapped[Event] = relationship(back_populates="results")
+    driver: Mapped[Driver] = relationship(back_populates="results")
+
+
+Index("ix_results_event_finish", Result.event_id, Result.finish_position)
+
+
+class DiscordIntegration(Base):
+    __tablename__ = "integrations_discord"
+    __table_args__ = (
+        UniqueConstraint("league_id", "guild_id", name="uq_integrations_discord_guild"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    league_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("leagues.id", ondelete="CASCADE"), nullable=False
+    )
+    guild_id: Mapped[str] = mapped_column(String, nullable=False)
+    channel_id: Mapped[str | None] = mapped_column(String)
+    installed_by_user: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+
+    league: Mapped[League] = relationship(back_populates="integrations")
+    installer: Mapped[User | None] = relationship("User", foreign_keys=[installed_by_user])
+
+
+class BillingAccount(Base):
+    __tablename__ = "billing_accounts"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    owner_user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    stripe_customer_id: Mapped[str | None] = mapped_column(String, unique=True)
+    plan: Mapped[str] = mapped_column(String, nullable=False, server_default=text("'FREE'"))
+    current_period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    owner: Mapped[User] = relationship(back_populates="billing_account")
+    subscriptions: Mapped[list[Subscription]] = relationship(back_populates="billing_account")
+
+
+class Subscription(Base):
+    __tablename__ = "subscriptions"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    billing_account_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("billing_accounts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    stripe_subscription_id: Mapped[str | None] = mapped_column(String, unique=True)
+    plan: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    billing_account: Mapped[BillingAccount] = relationship(back_populates="subscriptions")
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    actor_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    league_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("leagues.id", ondelete="CASCADE"), nullable=True
+    )
+    entity: Mapped[str] = mapped_column(String, nullable=False)
+    entity_id: Mapped[str | None] = mapped_column(String)
+    action: Mapped[str] = mapped_column(String, nullable=False)
+    before_state: Mapped[dict | None] = mapped_column(JSON)
+    after_state: Mapped[dict | None] = mapped_column(JSON)
+
+    actor: Mapped[User | None] = relationship(back_populates="audit_logs")
+    league: Mapped[League | None] = relationship(back_populates="audit_logs")

--- a/api/app/db/session.py
+++ b/api/app/db/session.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+DEFAULT_DATABASE_URL = "postgresql+psycopg://postgres:postgres@localhost:5432/gridboss"
+
+_engine: Engine | None = None
+SessionLocal: sessionmaker[Session] | None = None
+
+
+def get_engine(database_url: str | None = None) -> Engine:
+    """Create (or reuse) the SQLAlchemy engine."""
+    global _engine  # noqa: PLW0603 - cache engine for reuse
+
+    if _engine is None:
+        url = database_url or os.getenv("DATABASE_URL", DEFAULT_DATABASE_URL)
+        _engine = create_engine(url, future=True)
+    return _engine
+
+
+def get_sessionmaker() -> sessionmaker[Session]:
+    """Return the configured sessionmaker instance."""
+    global SessionLocal  # noqa: PLW0603 - cache sessionmaker
+
+    if SessionLocal is None:
+        engine = get_engine()
+        SessionLocal = sessionmaker(
+            bind=engine,
+            autoflush=False,
+            autocommit=False,
+            expire_on_commit=False,
+        )
+    return SessionLocal
+
+
+def get_session() -> Generator[Session, None, None]:
+    """FastAPI dependency-friendly session generator."""
+    session_factory = get_sessionmaker()
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()


### PR DESCRIPTION
Adds ORM baseline: SQLAlchemy Base + session helpers, full domain models with constraints/indexes, Alembic config, and the initial migration for all core GridBoss tables.