### PR TITLE
feat(api): add discord oauth authentication

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -37,3 +37,10 @@ Future PBIs will introduce:
 - Auth, RBAC, and API routes.
 - Background workers, Stripe integration, and Discord bot communication.
 - Automated tests and seed data.
+
+## Authentication
+- `GET /auth/discord/start` – begins the PKCE-based Discord OAuth flow.
+- `GET /auth/discord/callback` – exchanges the authorization code, persists the user, issues JWTs, and redirects to `APP_URL`.
+- `POST /auth/refresh` – rotates the refresh token cookie and returns a fresh access token.
+- `POST /auth/logout` – clears the refresh cookie.
+- `GET /auth/me` – returns the authenticated user profile, memberships, and billing snapshot.

--- a/api/app/core/__init__.py
+++ b/api/app/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core configuration utilities."""

--- a/api/app/core/security.py
+++ b/api/app/core/security.py
@@ -1,0 +1,72 @@
+﻿from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
+
+import jwt
+from fastapi import HTTPException, status
+
+from app.core.settings import Settings
+
+ALGORITHM = "HS256"
+ACCESS_TOKEN_TYPE = "access"  # noqa: S105
+REFRESH_TOKEN_TYPE = "refresh"  # noqa: S105
+
+
+class TokenError(HTTPException):
+    def __init__(
+        self, detail: str = "Invalid token", status_code: int = status.HTTP_401_UNAUTHORIZED
+    ) -> None:
+        super().__init__(status_code=status_code, detail=detail)
+
+
+def _create_token(
+    *, data: dict[str, Any], expires_delta: timedelta, settings: Settings, token_type: str
+) -> str:
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + expires_delta  # noqa: UP017
+    to_encode.update({"exp": expire, "type": token_type})
+    return jwt.encode(to_encode, settings.jwt_secret, algorithm=ALGORITHM)
+
+
+def create_access_token(*, subject: str, settings: Settings) -> str:
+    expires = timedelta(minutes=settings.jwt_access_ttl_min)
+    return _create_token(
+        data={"sub": subject},
+        expires_delta=expires,
+        settings=settings,
+        token_type=ACCESS_TOKEN_TYPE,
+    )
+
+
+def create_refresh_token(*, subject: str, settings: Settings) -> str:
+    expires = timedelta(days=settings.jwt_refresh_ttl_days)
+    token_id = secrets.token_urlsafe(32)
+    return _create_token(
+        data={"sub": subject, "jti": token_id},
+        expires_delta=expires,
+        settings=settings,
+        token_type=REFRESH_TOKEN_TYPE,
+    )
+
+
+def decode_token(
+    token: str, *, settings: Settings, expected_type: Literal["access", "refresh"]
+) -> dict[str, Any]:
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[ALGORITHM])
+    except jwt.ExpiredSignatureError as exc:
+        raise TokenError(detail="Token has expired") from exc
+    except jwt.InvalidTokenError as exc:
+        raise TokenError() from exc
+
+    token_type = payload.get("type")
+    if token_type != expected_type:
+        raise TokenError(detail="Incorrect token type")
+
+    subject = payload.get("sub")
+    if subject is None:
+        raise TokenError(detail="Token missing subject")
+
+    return payload

--- a/api/app/core/settings.py
+++ b/api/app/core/settings.py
@@ -1,0 +1,37 @@
+﻿from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import AnyHttpUrl, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore"
+    )
+
+    app_env: Literal["development", "production", "test"] = Field(
+        default="development", alias="APP_ENV"
+    )
+    app_url: AnyHttpUrl = Field(default="http://localhost:5173", alias="APP_URL")
+    api_url: AnyHttpUrl = Field(default="http://localhost:8000", alias="API_URL")
+
+    discord_client_id: str = Field(alias="DISCORD_CLIENT_ID")
+    discord_client_secret: str = Field(alias="DISCORD_CLIENT_SECRET")
+    discord_redirect_uri: AnyHttpUrl = Field(alias="DISCORD_REDIRECT_URI")
+
+    jwt_secret: str = Field(alias="JWT_SECRET")
+    jwt_access_ttl_min: int = Field(default=15, alias="JWT_ACCESS_TTL_MIN")
+    jwt_refresh_ttl_days: int = Field(default=14, alias="JWT_REFRESH_TTL_DAYS")
+
+    cors_origins: str = Field(default="http://localhost:5173", alias="CORS_ORIGINS")
+
+    def cookie_secure(self) -> bool:
+        return self.app_env == "production"
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    return Settings()

--- a/api/app/db/models.py
+++ b/api/app/db/models.py
@@ -1,8 +1,8 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import enum
 from datetime import datetime
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from sqlalchemy import (
     JSON,
@@ -37,6 +37,7 @@ class User(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     created_at: Mapped[datetime] = mapped_column(
@@ -63,6 +64,7 @@ class League(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     created_at: Mapped[datetime] = mapped_column(
@@ -94,6 +96,7 @@ class Membership(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     league_id: Mapped[UUID] = mapped_column(
@@ -117,6 +120,7 @@ class Team(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     league_id: Mapped[UUID] = mapped_column(
@@ -137,6 +141,7 @@ class Driver(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     league_id: Mapped[UUID] = mapped_column(
@@ -163,6 +168,7 @@ class Season(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     league_id: Mapped[UUID] = mapped_column(
@@ -188,6 +194,7 @@ class Event(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     league_id: Mapped[UUID] = mapped_column(
@@ -224,6 +231,7 @@ class PointsScheme(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     league_id: Mapped[UUID] = mapped_column(
@@ -248,6 +256,7 @@ class PointsRule(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     scheme_id: Mapped[UUID] = mapped_column(
@@ -273,6 +282,7 @@ class Result(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     event_id: Mapped[UUID] = mapped_column(
@@ -306,6 +316,7 @@ class DiscordIntegration(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     league_id: Mapped[UUID] = mapped_column(
@@ -328,6 +339,7 @@ class BillingAccount(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     owner_user_id: Mapped[UUID] = mapped_column(
@@ -347,6 +359,7 @@ class Subscription(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     billing_account_id: Mapped[UUID] = mapped_column(
@@ -370,6 +383,7 @@ class AuditLog(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         primary_key=True,
+        default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
     timestamp: Mapped[datetime] = mapped_column(

--- a/api/app/dependencies/__init__.py
+++ b/api/app/dependencies/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI dependency providers."""

--- a/api/app/dependencies/auth.py
+++ b/api/app/dependencies/auth.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.security import ACCESS_TOKEN_TYPE, decode_token
+from app.core.settings import Settings, get_settings
+from app.db.models import User
+from app.db.session import get_session
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+SessionDep = Annotated[Session, Depends(get_session)]
+CredentialsDep = Annotated[HTTPAuthorizationCredentials | None, Depends(bearer_scheme)]
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+
+async def get_current_user(
+    request: Request,
+    session: SessionDep,
+    credentials: CredentialsDep,
+    settings: SettingsDep,
+) -> User:
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing credentials")
+
+    payload = decode_token(
+        credentials.credentials, settings=settings, expected_type=ACCESS_TOKEN_TYPE
+    )
+    subject = payload.get("sub")
+    try:
+        user_id = UUID(subject)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token subject"
+        ) from exc
+
+    user = session.execute(select(User).where(User.id == user_id)).scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    if not user.is_active:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User is inactive")
+    return user

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,6 +1,26 @@
-﻿from fastapi import FastAPI
+﻿from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.core.settings import get_settings
+from app.routes import auth
+
+settings = get_settings()
 
 app = FastAPI(title="GridBoss API", version="0.1.0")
+
+allowed_origins = [origin.strip() for origin in settings.cors_origins.split(",") if origin.strip()]
+if allowed_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allowed_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+app.include_router(auth.router)
 
 
 @app.get("/healthz", tags=["health"])

--- a/api/app/routes/__init__.py
+++ b/api/app/routes/__init__.py
@@ -1,0 +1,5 @@
+"""API route modules."""
+
+from . import auth
+
+__all__ = ["auth"]

--- a/api/app/routes/auth.py
+++ b/api/app/routes/auth.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from typing import Annotated
+from urllib.parse import urlencode
+from uuid import UUID
+
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
+from fastapi.responses import RedirectResponse
+from sqlalchemy import select
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.security import (
+    REFRESH_TOKEN_TYPE,
+    TokenError,
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+)
+from app.core.settings import Settings, get_settings
+from app.db.models import BillingAccount, Membership, User
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.schemas.auth import BillingPlanOut, MembershipOut, MeResponse, TokenResponse, UserOut
+from app.services.discord import DiscordOAuthClient, get_discord_client
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+PKCE_COOKIE = "gb_pkce_verifier"
+STATE_COOKIE = "gb_oauth_state"
+REFRESH_COOKIE = "gb_refresh_token"
+STATE_TTL_SECONDS = 300
+
+RefreshCookie = Annotated[str | None, Cookie(alias=REFRESH_COOKIE)]
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+SessionDep = Annotated[Session, Depends(get_session)]
+CurrentUserDep = Annotated[User, Depends(get_current_user)]
+
+
+def _set_refresh_cookie(response: Response, *, token: str, settings: Settings) -> None:
+    response.set_cookie(
+        REFRESH_COOKIE,
+        value=token,
+        httponly=True,
+        secure=settings.cookie_secure(),
+        samesite="lax",
+        max_age=settings.jwt_refresh_ttl_days * 24 * 60 * 60,
+    )
+
+
+def _clear_oauth_cookies(response: Response, settings: Settings) -> None:
+    response.delete_cookie(PKCE_COOKIE, secure=settings.cookie_secure(), samesite="lax")
+    response.delete_cookie(STATE_COOKIE, secure=settings.cookie_secure(), samesite="lax")
+
+
+def _clear_refresh_cookie(response: Response, settings: Settings) -> None:
+    response.delete_cookie(REFRESH_COOKIE, secure=settings.cookie_secure(), samesite="lax")
+
+
+def provide_discord_client(settings: SettingsDep) -> DiscordOAuthClient:
+    return get_discord_client(settings)
+
+
+DiscordClientDep = Annotated[DiscordOAuthClient, Depends(provide_discord_client)]
+
+
+@router.get("/discord/start", status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+async def discord_start(settings: SettingsDep) -> Response:
+    verifier = secrets.token_urlsafe(64)
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("utf-8")).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    state = secrets.token_urlsafe(32)
+
+    params = {
+        "response_type": "code",
+        "client_id": settings.discord_client_id,
+        "scope": "identify email",
+        "redirect_uri": str(settings.discord_redirect_uri),
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    authorize_url = f"https://discord.com/api/oauth2/authorize?{urlencode(params)}"
+
+    redirect = RedirectResponse(authorize_url, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+    redirect.set_cookie(
+        PKCE_COOKIE,
+        value=verifier,
+        max_age=STATE_TTL_SECONDS,
+        secure=settings.cookie_secure(),
+        httponly=True,
+        samesite="lax",
+    )
+    redirect.set_cookie(
+        STATE_COOKIE,
+        value=state,
+        max_age=STATE_TTL_SECONDS,
+        secure=settings.cookie_secure(),
+        httponly=True,
+        samesite="lax",
+    )
+    return redirect
+
+
+@router.get("/discord/callback", status_code=status.HTTP_302_FOUND)
+async def discord_callback(
+    request: Request,
+    settings: SettingsDep,
+    session: SessionDep,
+    client: DiscordClientDep,
+) -> Response:
+    code = request.query_params.get("code")
+    state = request.query_params.get("state")
+    if not code or not state:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing code or state")
+
+    stored_state = request.cookies.get(STATE_COOKIE)
+    verifier = request.cookies.get(PKCE_COOKIE)
+    if stored_state is None or verifier is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth session expired")
+    if stored_state != state:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth state mismatch")
+
+    try:
+        token_payload = await client.exchange_code(code=code, code_verifier=verifier)
+        user_payload = await client.fetch_user(access_token=token_payload["access_token"])
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY, detail="Discord OAuth failed"
+        ) from exc
+
+    discord_id = user_payload.get("id")
+    if not discord_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Discord user missing id"
+        )
+
+    user = session.execute(select(User).where(User.discord_id == discord_id)).scalar_one_or_none()
+    if user is None:
+        user = User(discord_id=discord_id)
+        session.add(user)
+
+    user.discord_username = user_payload.get("username")
+    user.avatar_url = user_payload.get("avatar")
+    user.email = user_payload.get("email")
+    user.is_active = True
+    session.commit()
+
+    access_token = create_access_token(subject=str(user.id), settings=settings)
+    refresh_token = create_refresh_token(subject=str(user.id), settings=settings)
+
+    redirect_url = f"{settings.app_url}?{urlencode({'access_token': access_token})}"
+    redirect_response = RedirectResponse(redirect_url, status_code=status.HTTP_302_FOUND)
+    _set_refresh_cookie(redirect_response, token=refresh_token, settings=settings)
+    _clear_oauth_cookies(redirect_response, settings=settings)
+    redirect_response.headers["Cache-Control"] = "no-store"
+    return redirect_response
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh_token(
+    response: Response,
+    settings: SettingsDep,
+    session: SessionDep,
+    refresh_cookie: RefreshCookie = None,
+) -> TokenResponse:
+    if not refresh_cookie:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Refresh token missing"
+        )
+
+    try:
+        payload = decode_token(refresh_cookie, settings=settings, expected_type=REFRESH_TOKEN_TYPE)
+    except TokenError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    try:
+        user_id = UUID(str(payload.get("sub")))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token subject"
+        ) from exc
+
+    user = session.execute(select(User).where(User.id == user_id)).scalar_one_or_none()
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    new_access = create_access_token(subject=str(user.id), settings=settings)
+    new_refresh = create_refresh_token(subject=str(user.id), settings=settings)
+    _set_refresh_cookie(response, token=new_refresh, settings=settings)
+    return TokenResponse(access_token=new_access)
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(response: Response, settings: SettingsDep) -> Response:
+    _clear_refresh_cookie(response, settings=settings)
+    response.status_code = status.HTTP_204_NO_CONTENT
+    return response
+
+
+@router.get("/me", response_model=MeResponse)
+async def read_me(
+    current_user: CurrentUserDep,
+    session: SessionDep,
+) -> MeResponse:
+    memberships_query = (
+        select(Membership)
+        .where(Membership.user_id == current_user.id)
+        .options(joinedload(Membership.league))
+    )
+    memberships = session.execute(memberships_query).scalars().all()
+
+    membership_out: list[MembershipOut] = [
+        MembershipOut(
+            league_id=item.league_id,
+            league_slug=item.league.slug,
+            league_name=item.league.name,
+            role=item.role,
+        )
+        for item in memberships
+    ]
+
+    billing_account = session.execute(
+        select(BillingAccount).where(BillingAccount.owner_user_id == current_user.id)
+    ).scalar_one_or_none()
+
+    billing = (
+        BillingPlanOut(
+            plan=billing_account.plan, current_period_end=billing_account.current_period_end
+        )
+        if billing_account
+        else None
+    )
+
+    return MeResponse(
+        user=UserOut.model_validate(current_user), memberships=membership_out, billingPlan=billing
+    )

--- a/api/app/schemas/__init__.py
+++ b/api/app/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic response/request schemas."""

--- a/api/app/schemas/auth.py
+++ b/api/app/schemas/auth.py
@@ -1,0 +1,42 @@
+﻿from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from app.db.models import LeagueRole
+
+
+class UserOut(BaseModel):
+    id: UUID
+    discord_id: str | None
+    discord_username: str | None
+    avatar_url: str | None
+    email: str | None
+
+    class Config:
+        from_attributes = True
+
+
+class MembershipOut(BaseModel):
+    league_id: UUID
+    league_slug: str
+    league_name: str
+    role: LeagueRole
+
+
+class BillingPlanOut(BaseModel):
+    plan: str | None
+    current_period_end: datetime | None
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class MeResponse(BaseModel):
+    user: UserOut
+    memberships: list[MembershipOut]
+    billingPlan: BillingPlanOut | None

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""External service clients."""

--- a/api/app/services/discord.py
+++ b/api/app/services/discord.py
@@ -1,0 +1,44 @@
+﻿from __future__ import annotations
+
+import httpx
+
+from app.core.settings import Settings
+
+TOKEN_URL = "https://discord.com/api/oauth2/token"  # noqa: S105
+USER_URL = "https://discord.com/api/users/@me"
+
+
+class DiscordOAuthClient:
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+
+    async def exchange_code(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+    ) -> dict[str, str]:
+        data = {
+            "client_id": self.settings.discord_client_id,
+            "client_secret": self.settings.discord_client_secret,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": str(self.settings.discord_redirect_uri),
+            "code_verifier": code_verifier,
+        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(TOKEN_URL, data=data, headers=headers)
+            response.raise_for_status()
+            return response.json()
+
+    async def fetch_user(self, *, access_token: str) -> dict[str, str]:
+        headers = {"Authorization": f"Bearer {access_token}"}
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(USER_URL, headers=headers)
+            response.raise_for_status()
+            return response.json()
+
+
+def get_discord_client(settings: Settings) -> DiscordOAuthClient:
+    return DiscordOAuthClient(settings)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.115.5
+﻿fastapi==0.115.5
 uvicorn[standard]==0.32.0
 sqlalchemy==2.0.36
 alembic==1.13.2
@@ -7,3 +7,5 @@ pydantic==2.9.2
 pydantic-settings==2.10.1
 redis==5.2.0
 python-dotenv==1.0.1
+httpx==0.28.1
+PyJWT==2.9.0

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1,0 +1,195 @@
+﻿from __future__ import annotations
+
+from collections.abc import Generator
+from http import HTTPStatus
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.settings import Settings, get_settings
+from app.db import Base
+from app.db.models import User
+from app.db.session import get_session
+from app.main import app
+from app.routes.auth import provide_discord_client
+
+SQLALCHEMY_DATABASE_URL = "sqlite+pysqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    future=True,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(
+    bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+)
+
+
+class StubDiscordClient:
+    def __init__(self) -> None:  # pragma: no cover - settings unused in stub
+        pass
+
+    async def exchange_code(self, *, code: str, code_verifier: str) -> dict[str, str]:
+        return {"access_token": "discord_token"}
+
+    async def fetch_user(self, *, access_token: str) -> dict[str, str]:
+        return {
+            "id": "1234567890",
+            "username": "TestDriver",
+            "avatar": "avatar.png",
+            "email": "driver@example.com",
+        }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_database() -> None:
+    for table in Base.metadata.sorted_tables:
+        for column in table.c:
+            default = getattr(column, "server_default", None)
+            if default is not None and "gen_random_uuid" in str(default.arg):
+                column.server_default = None
+    Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies() -> Generator[None, None, None]:
+    test_settings = Settings(
+        APP_ENV="test",
+        APP_URL="http://localhost:5173",
+        API_URL="http://localhost:8000",
+        DISCORD_CLIENT_ID="client",
+        DISCORD_CLIENT_SECRET="secret",  # noqa: S106
+        DISCORD_REDIRECT_URI="http://localhost:8000/auth/discord/callback",
+        JWT_SECRET="test-secret",  # noqa: S106
+        JWT_ACCESS_TTL_MIN=15,
+        JWT_REFRESH_TTL_DAYS=14,
+        CORS_ORIGINS="http://localhost:5173",
+    )
+
+    get_settings.cache_clear()
+    import app.main as app_main
+
+    app_main.settings = test_settings
+
+    def get_test_settings() -> Settings:
+        return test_settings
+
+    def get_test_session() -> Generator[Session, None, None]:
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_settings] = get_test_settings
+    app.dependency_overrides[get_session] = get_test_session
+    app.dependency_overrides[provide_discord_client] = lambda: StubDiscordClient()
+
+    yield
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+class TestAuthFlow:
+    def test_redirect_sets_cookies(self, client: TestClient) -> None:
+        response = client.get("/auth/discord/start", allow_redirects=False)
+        assert response.status_code == HTTPStatus.TEMPORARY_REDIRECT
+        assert "discord.com/api/oauth2/authorize" in response.headers["location"]
+        assert "gb_pkce_verifier" in response.cookies
+        assert "gb_oauth_state" in response.cookies
+
+    def test_callback_creates_user_and_sets_tokens(self, client: TestClient) -> None:
+        start_response = client.get("/auth/discord/start", allow_redirects=False)
+        state_cookie = start_response.cookies.get("gb_oauth_state")
+        verifier_cookie = start_response.cookies.get("gb_pkce_verifier")
+
+        callback_response = client.get(
+            "/auth/discord/callback",
+            params={"code": "fake-code", "state": state_cookie},
+            headers={
+                "Cookie": f"gb_oauth_state={state_cookie}; gb_pkce_verifier={verifier_cookie}"
+            },
+            allow_redirects=False,
+        )
+
+        assert callback_response.status_code == HTTPStatus.FOUND
+        assert "gb_refresh_token" in callback_response.cookies
+
+        redirect_url = callback_response.headers["location"]
+        parsed = urlparse(redirect_url)
+        access_token = parse_qs(parsed.query).get("access_token", [None])[0]
+        assert access_token is not None
+
+        db: Session = TestingSessionLocal()
+        try:
+            assert db.query(User).count() == 1
+        finally:
+            db.close()
+
+    def test_refresh_rotates_tokens(self, client: TestClient) -> None:
+        start_response = client.get("/auth/discord/start", allow_redirects=False)
+        state_cookie = start_response.cookies.get("gb_oauth_state")
+        verifier_cookie = start_response.cookies.get("gb_pkce_verifier")
+        callback_response = client.get(
+            "/auth/discord/callback",
+            params={"code": "fake-code", "state": state_cookie},
+            headers={
+                "Cookie": f"gb_oauth_state={state_cookie}; gb_pkce_verifier={verifier_cookie}"
+            },
+            allow_redirects=False,
+        )
+        refresh_cookie = callback_response.cookies.get("gb_refresh_token")
+
+        client.cookies.set("gb_refresh_token", refresh_cookie)
+        refresh_response = client.post("/auth/refresh")
+        assert refresh_response.status_code == HTTPStatus.OK, refresh_response.json()
+        body = refresh_response.json()
+        assert "access_token" in body
+
+    def test_me_requires_auth(self, client: TestClient) -> None:
+        unauth = client.get("/auth/me")
+        assert unauth.status_code == HTTPStatus.UNAUTHORIZED
+
+        start_response = client.get("/auth/discord/start", allow_redirects=False)
+        state_cookie = start_response.cookies.get("gb_oauth_state")
+        verifier_cookie = start_response.cookies.get("gb_pkce_verifier")
+        callback_response = client.get(
+            "/auth/discord/callback",
+            params={"code": "fake-code", "state": state_cookie},
+            headers={
+                "Cookie": f"gb_oauth_state={state_cookie}; gb_pkce_verifier={verifier_cookie}"
+            },
+            allow_redirects=False,
+        )
+
+        refresh_cookie = callback_response.cookies.get("gb_refresh_token")
+        # rotate to ensure cookies valid for me request
+        client.cookies.set("gb_refresh_token", refresh_cookie)
+        refresh_response = client.post("/auth/refresh")
+        assert refresh_response.status_code == HTTPStatus.OK, refresh_response.json()
+        new_access_token = refresh_response.json()["access_token"]
+
+        me_response = client.get(
+            "/auth/me",
+            headers={"Authorization": f"Bearer {new_access_token}"},
+        )
+        assert me_response.status_code == HTTPStatus.OK, me_response.json()
+        payload = me_response.json()
+        assert payload["user"]["discord_id"] == "1234567890"
+        assert payload["memberships"] == []
+
+    def test_logout_clears_cookie(self, client: TestClient) -> None:
+        client.cookies.set("gb_refresh_token", "dummy")
+        response = client.post("/auth/logout")
+        assert response.status_code == HTTPStatus.NO_CONTENT
+        assert "gb_refresh_token=" in response.headers.get("set-cookie", "")


### PR DESCRIPTION
Adds Discord OAuth + JWT session service: settings loader, token helpers, /auth routes, Discord client, schemas, UUID defaults for tests, and end-to-end auth flow tests.

Tests

ruff check
black --check api/app api/tests
python -m pytest