### PR TITLE
feat(api): deliver drivers and teams API (PBI-007)

### DIFF
--- a/api/app/core/errors.py
+++ b/api/app/core/errors.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+
+def api_error(*, status_code: int, code: str, message: str, field: str | None = None) -> HTTPException:
+    """Construct an HTTPException with our standard error envelope."""
+    error_body: dict[str, Any] = {"code": code, "message": message}
+    if field is not None:
+        error_body["field"] = field
+    return HTTPException(status_code=status_code, detail={"error": error_body})

--- a/api/app/routes/__init__.py
+++ b/api/app/routes/__init__.py
@@ -1,5 +1,5 @@
 """API route modules."""
 
-from . import auth, leagues, memberships
+from . import auth, drivers, leagues, memberships, teams
 
-__all__ = ["auth", "leagues", "memberships"]
+__all__ = ["auth", "drivers", "leagues", "memberships", "teams"]

--- a/api/app/routes/drivers.py
+++ b/api/app/routes/drivers.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.errors import api_error
+from app.db.models import Driver, League, LeagueRole, Team, User
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.schemas.drivers import DriverBulkCreate, DriverRead, DriverUpdate
+from app.services.rbac import require_membership, require_role_at_least
+
+router = APIRouter(tags=["drivers"])
+
+SessionDep = Annotated[Session, Depends(get_session)]
+CurrentUserDep = Annotated[User, Depends(get_current_user)]
+
+
+def _get_league(session: Session, league_id: UUID) -> League:
+    league = session.get(League, league_id)
+    if league is None or league.is_deleted:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="LEAGUE_NOT_FOUND",
+            message="League not found",
+        )
+    return league
+
+
+def _driver_to_read(driver: Driver) -> DriverRead:
+    return DriverRead(
+        id=driver.id,
+        league_id=driver.league_id,
+        display_name=driver.display_name,
+        user_id=driver.user_id,
+        discord_id=driver.discord_id,
+        team_id=driver.team_id,
+        team_name=driver.team.name if driver.team else None,
+    )
+
+
+@router.get("/leagues/{league_id}/drivers", response_model=list[DriverRead])
+async def list_drivers(
+    league_id: UUID,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> list[DriverRead]:
+    _get_league(session, league_id)
+    require_membership(session, league_id=league_id, user_id=current_user.id)
+
+    drivers = (
+        session.execute(
+            select(Driver)
+            .options(joinedload(Driver.team))
+            .where(Driver.league_id == league_id)
+            .order_by(Driver.display_name)
+        )
+        .scalars()
+        .all()
+    )
+    return [_driver_to_read(driver) for driver in drivers]
+
+
+@router.post(
+    "/leagues/{league_id}/drivers",
+    response_model=list[DriverRead],
+    status_code=status.HTTP_201_CREATED,
+)
+async def bulk_create_drivers(
+    league_id: UUID,
+    payload: DriverBulkCreate,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> list[DriverRead]:
+    league = _get_league(session, league_id)
+    membership = require_membership(session, league_id=league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    normalized_name_map: dict[str, str] = {}
+    sanitized_items: list[tuple[str, UUID | None]] = []
+    for item in payload.items:
+        name = item.display_name.strip()
+        if not name:
+            raise api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="INVALID_NAME",
+                message="Driver display name is required",
+                field="display_name",
+            )
+        lowered = name.lower()
+        if lowered in normalized_name_map:
+            raise api_error(
+                status_code=status.HTTP_409_CONFLICT,
+                code="DUPLICATE_DRIVER",
+                message="Duplicate driver names in request",
+                field="display_name",
+            )
+        normalized_name_map[lowered] = name
+        sanitized_items.append((name, item.team_id))
+
+    team_ids = {team_id for (_, team_id) in sanitized_items if team_id is not None}
+    if team_ids:
+        teams = (
+            session.execute(select(Team).where(Team.id.in_(team_ids), Team.league_id == league_id))
+            .scalars()
+            .all()
+        )
+        found_team_ids = {team.id for team in teams}
+        missing = team_ids - found_team_ids
+        if missing:
+            raise api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="INVALID_TEAM",
+                message="One or more teams do not belong to this league",
+                field="team_id",
+            )
+
+    existing_names = {
+        name.lower()
+        for name in session.execute(
+            select(Driver.display_name).where(Driver.league_id == league_id)
+        ).scalars()
+    }
+    conflict = next((name for name in normalized_name_map if name in existing_names), None)
+    if conflict is not None:
+        raise api_error(
+            status_code=status.HTTP_409_CONFLICT,
+            code="DUPLICATE_DRIVER",
+            message="Driver name already exists",
+            field="display_name",
+        )
+
+    current_count = session.execute(
+        select(func.count(Driver.id)).where(Driver.league_id == league_id)
+    ).scalar_one()
+    if current_count + len(sanitized_items) > league.driver_limit:
+        raise api_error(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            code="PLAN_LIMIT",
+            message="Driver limit reached for current plan",
+        )
+
+    drivers_to_create = [
+        Driver(league_id=league_id, display_name=name, team_id=team_id)
+        for name, team_id in sanitized_items
+    ]
+    session.add_all(drivers_to_create)
+    session.commit()
+
+    created_driver_ids = [driver.id for driver in drivers_to_create]
+    created_drivers = (
+        session.execute(
+            select(Driver)
+            .options(joinedload(Driver.team))
+            .where(Driver.id.in_(created_driver_ids))
+        )
+        .scalars()
+        .all()
+    )
+    created_lookup = {driver.id: driver for driver in created_drivers}
+    return [_driver_to_read(created_lookup[driver_id]) for driver_id in created_driver_ids]
+
+
+@router.patch("/drivers/{driver_id}", response_model=DriverRead)
+async def update_driver(
+    driver_id: UUID,
+    payload: DriverUpdate,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> DriverRead:
+    driver = session.get(Driver, driver_id)
+    if driver is None:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="DRIVER_NOT_FOUND",
+            message="Driver not found",
+        )
+
+    membership = require_membership(session, league_id=driver.league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    update_data = payload.model_dump(exclude_unset=True)
+    if "display_name" in update_data:
+        raw_name = update_data["display_name"]
+        new_name = raw_name.strip() if raw_name else ""
+        if not new_name:
+            raise api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="INVALID_NAME",
+                message="Driver display name is required",
+                field="display_name",
+            )
+        existing = session.execute(
+            select(Driver)
+            .where(
+                Driver.league_id == driver.league_id,
+                func.lower(Driver.display_name) == new_name.lower(),
+                Driver.id != driver.id,
+            )
+        ).scalars().first()
+        if existing:
+            raise api_error(
+                status_code=status.HTTP_409_CONFLICT,
+                code="DUPLICATE_DRIVER",
+                message="Driver name already exists",
+                field="display_name",
+            )
+        driver.display_name = new_name
+
+    if "team_id" in update_data:
+        team_id = update_data["team_id"]
+        if team_id is not None:
+            team = session.get(Team, team_id)
+            if team is None or team.league_id != driver.league_id:
+                raise api_error(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    code="INVALID_TEAM",
+                    message="Team does not belong to this league",
+                    field="team_id",
+                )
+        driver.team_id = team_id
+
+    session.commit()
+    session.refresh(driver)
+    return _driver_to_read(driver)
+
+
+@router.delete("/drivers/{driver_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
+async def delete_driver(
+    driver_id: UUID,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> Response:
+    driver = session.get(Driver, driver_id)
+    if driver is None:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="DRIVER_NOT_FOUND",
+            message="Driver not found",
+        )
+
+    membership = require_membership(session, league_id=driver.league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    session.delete(driver)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+

--- a/api/app/routes/teams.py
+++ b/api/app/routes/teams.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.core.errors import api_error
+from app.db.models import Driver, League, LeagueRole, Team, User
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.schemas.teams import TeamCreate, TeamRead, TeamUpdate
+from app.services.rbac import require_membership, require_role_at_least
+
+router = APIRouter(tags=["teams"])
+
+SessionDep = Annotated[Session, Depends(get_session)]
+CurrentUserDep = Annotated[User, Depends(get_current_user)]
+
+
+def _get_league(session: Session, league_id: UUID) -> League:
+    league = session.get(League, league_id)
+    if league is None or league.is_deleted:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="LEAGUE_NOT_FOUND",
+            message="League not found",
+        )
+    return league
+
+
+def _team_to_read(team: Team, driver_count: int) -> TeamRead:
+    return TeamRead(
+        id=team.id,
+        league_id=team.league_id,
+        name=team.name,
+        driver_count=driver_count,
+    )
+
+
+@router.get("/leagues/{league_id}/teams", response_model=list[TeamRead])
+async def list_teams(
+    league_id: UUID,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> list[TeamRead]:
+    _get_league(session, league_id)
+    require_membership(session, league_id=league_id, user_id=current_user.id)
+
+    rows = (
+        session.execute(
+            select(Team, func.count(Driver.id))
+            .outerjoin(Driver, Driver.team_id == Team.id)
+            .where(Team.league_id == league_id)
+            .group_by(Team.id)
+            .order_by(Team.name)
+        )
+        .all()
+    )
+    return [_team_to_read(team, driver_count) for team, driver_count in rows]
+
+
+@router.post(
+    "/leagues/{league_id}/teams",
+    response_model=TeamRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_team(
+    league_id: UUID,
+    payload: TeamCreate,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> TeamRead:
+    _get_league(session, league_id)
+    membership = require_membership(session, league_id=league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    name = payload.name.strip()
+    if not name:
+        raise api_error(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code="INVALID_NAME",
+            message="Team name is required",
+            field="name",
+        )
+
+    existing = session.execute(
+        select(Team).where(
+            Team.league_id == league_id,
+            func.lower(Team.name) == name.lower(),
+        )
+    ).scalars().first()
+    if existing:
+        raise api_error(
+            status_code=status.HTTP_409_CONFLICT,
+            code="DUPLICATE_TEAM",
+            message="Team name already exists",
+            field="name",
+        )
+
+    team = Team(league_id=league_id, name=name)
+    session.add(team)
+    session.commit()
+    session.refresh(team)
+    return _team_to_read(team, driver_count=0)
+
+
+@router.patch("/teams/{team_id}", response_model=TeamRead)
+async def update_team(
+    team_id: UUID,
+    payload: TeamUpdate,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> TeamRead:
+    team = session.get(Team, team_id)
+    if team is None:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="TEAM_NOT_FOUND",
+            message="Team not found",
+        )
+
+    membership = require_membership(session, league_id=team.league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    update_data = payload.model_dump(exclude_unset=True)
+    if "name" in update_data:
+        raw_name = update_data["name"]
+        new_name = raw_name.strip() if raw_name else ""
+        if not new_name:
+            raise api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="INVALID_NAME",
+                message="Team name is required",
+                field="name",
+            )
+        existing = session.execute(
+            select(Team).where(
+                Team.league_id == team.league_id,
+                func.lower(Team.name) == new_name.lower(),
+                Team.id != team.id,
+            )
+        ).scalars().first()
+        if existing:
+            raise api_error(
+                status_code=status.HTTP_409_CONFLICT,
+                code="DUPLICATE_TEAM",
+                message="Team name already exists",
+                field="name",
+            )
+        team.name = new_name
+
+    session.commit()
+    session.refresh(team)
+
+    driver_count = session.execute(
+        select(func.count(Driver.id)).where(Driver.team_id == team.id)
+    ).scalar_one()
+    return _team_to_read(team, driver_count)
+
+
+@router.delete("/teams/{team_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
+async def delete_team(
+    team_id: UUID,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> Response:
+    team = session.get(Team, team_id)
+    if team is None:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="TEAM_NOT_FOUND",
+            message="Team not found",
+        )
+
+    membership = require_membership(session, league_id=team.league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    drivers = (
+        session.execute(
+            select(Driver).where(Driver.league_id == team.league_id, Driver.team_id == team.id)
+        ).scalars().all()
+    )
+    for driver in drivers:
+        driver.team_id = None
+
+    session.delete(team)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+

--- a/api/app/schemas/drivers.py
+++ b/api/app/schemas/drivers.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class DriverCreateItem(BaseModel):
+    display_name: str = Field(min_length=1)
+    team_id: UUID | None = None
+
+
+class DriverBulkCreate(BaseModel):
+    items: list[DriverCreateItem] = Field(min_length=1)
+
+
+class DriverUpdate(BaseModel):
+    display_name: str | None = Field(default=None, min_length=1)
+    team_id: UUID | None = Field(default=None)
+
+
+class DriverRead(BaseModel):
+    id: UUID
+    league_id: UUID
+    display_name: str
+    user_id: UUID | None
+    discord_id: str | None
+    team_id: UUID | None
+    team_name: str | None
+
+    class Config:
+        from_attributes = True

--- a/api/app/schemas/teams.py
+++ b/api/app/schemas/teams.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class TeamCreate(BaseModel):
+    name: str = Field(min_length=1)
+
+
+class TeamUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1)
+
+
+class TeamRead(BaseModel):
+    id: UUID
+    league_id: UUID
+    name: str
+    driver_count: int
+
+    class Config:
+        from_attributes = True

--- a/api/app/services/rbac.py
+++ b/api/app/services/rbac.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import api_error
+from app.db.models import LeagueRole, Membership
+
+ROLE_PRIORITY = {
+    LeagueRole.DRIVER: 1,
+    LeagueRole.STEWARD: 2,
+    LeagueRole.ADMIN: 3,
+    LeagueRole.OWNER: 4,
+}
+
+def require_membership(session: Session, *, league_id: UUID, user_id: UUID) -> Membership:
+    membership = session.execute(
+        select(Membership).where(Membership.league_id == league_id, Membership.user_id == user_id)
+    ).scalar_one_or_none()
+    if membership is None:
+        raise api_error(
+            status_code=status.HTTP_403_FORBIDDEN,
+            code="NOT_A_MEMBER",
+            message="Not a member of this league",
+        )
+    return membership
+
+def require_role_at_least(membership: Membership, *, minimum: LeagueRole) -> None:
+    required_rank = ROLE_PRIORITY[minimum]
+    actual_rank = ROLE_PRIORITY[membership.role]
+    if actual_rank < required_rank:
+        raise api_error(
+            status_code=status.HTTP_403_FORBIDDEN,
+            code="INSUFFICIENT_ROLE",
+            message="Insufficient permissions for this action",
+        )

--- a/api/tests/test_drivers.py
+++ b/api/tests/test_drivers.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from http import HTTPStatus
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.settings import Settings, get_settings
+from app.db import Base
+from app.db.models import Driver, League, LeagueRole, Membership, Team, User
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.routes.auth import provide_discord_client
+
+SQLALCHEMY_DATABASE_URL = "sqlite+pysqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    future=True,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+)
+
+
+class StubDiscordClient:
+    def __init__(self) -> None:  # pragma: no cover
+        pass
+
+    async def exchange_code(self, *, code: str, code_verifier: str) -> dict[str, str]:
+        return {"access_token": "token"}
+
+    async def fetch_user(self, *, access_token: str) -> dict[str, str]:
+        return {
+            "id": "123",
+            "username": "Stub",
+            "avatar": None,
+            "email": None,
+        }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_database() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies() -> Generator[None, None, None]:
+    get_settings.cache_clear()
+
+    test_settings = Settings(
+        APP_ENV="test",
+        APP_URL="http://localhost:5173",
+        API_URL="http://localhost:8000",
+        DISCORD_CLIENT_ID="client",
+        DISCORD_CLIENT_SECRET="secret",  # noqa: S106
+        DISCORD_REDIRECT_URI="http://localhost:8000/auth/discord/callback",
+        JWT_SECRET="test-secret",  # noqa: S106
+        JWT_ACCESS_TTL_MIN=15,
+        JWT_REFRESH_TTL_DAYS=14,
+        CORS_ORIGINS="http://localhost:5173",
+    )
+
+    app.dependency_overrides[get_settings] = lambda: test_settings
+
+    def get_test_session() -> Generator[Session, None, None]:
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_session] = get_test_session
+    app.dependency_overrides[provide_discord_client] = lambda: StubDiscordClient()
+
+    yield
+
+    app.dependency_overrides.clear()
+
+
+@contextmanager
+def override_user(user: User) -> Generator[None, None, None]:
+    app.dependency_overrides[get_current_user] = lambda: user
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def database_session() -> Generator[Session, None, None]:
+    session = TestingSessionLocal()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def stub_user(session: Session, discord_id: str) -> User:
+    user = User(discord_id=discord_id, discord_username=discord_id)
+    session.add(user)
+    session.commit()
+    return user
+
+
+def create_league_with_owner(
+    session: Session,
+    owner: User,
+    *,
+    driver_limit: int = 20,
+) -> League:
+    league = League(
+        name="Test League",
+        slug=f"league-{uuid4().hex[:8]}",
+        owner_id=owner.id,
+        driver_limit=driver_limit,
+    )
+    session.add(league)
+    session.commit()
+    session.refresh(league)
+
+    membership = Membership(league_id=league.id, user_id=owner.id, role=LeagueRole.OWNER)
+    session.add(membership)
+    session.commit()
+    return league
+
+
+def create_team(session: Session, league: League, name: str) -> Team:
+    team = Team(league_id=league.id, name=name)
+    session.add(team)
+    session.commit()
+    session.refresh(team)
+    return team
+
+
+class TestDriverRoutes:
+    def test_bulk_create_drivers_success(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner, driver_limit=10)
+        team = create_team(database_session, league, "Alpha")
+
+        payload = {
+            "items": [
+                {"display_name": "Driver One", "team_id": str(team.id)},
+                {"display_name": "Driver Two"},
+            ]
+        }
+
+        with override_user(owner):
+            response = client.post(f"/leagues/{league.id}/drivers", json=payload)
+
+        assert response.status_code == HTTPStatus.CREATED, response.text
+        data = response.json()
+        assert [item["display_name"] for item in data] == ["Driver One", "Driver Two"]
+        assert data[0]["team_id"] == str(team.id)
+        assert data[0]["team_name"] == "Alpha"
+        assert data[1]["team_id"] is None
+        assert data[1]["user_id"] is None
+        assert data[1]["discord_id"] is None
+
+        drivers = (
+            database_session.execute(select(Driver).where(Driver.league_id == league.id))
+            .scalars()
+            .all()
+        )
+        assert len(drivers) == 2
+
+    def test_bulk_create_drivers_duplicate_conflict(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner)
+        database_session.add(Driver(league_id=league.id, display_name="Driver One"))
+        database_session.commit()
+
+        payload = {"items": [{"display_name": "Driver One"}]}
+        with override_user(owner):
+            response = client.post(f"/leagues/{league.id}/drivers", json=payload)
+
+        assert response.status_code == HTTPStatus.CONFLICT
+        assert response.json()["error"]["code"] == "DUPLICATE_DRIVER"
+
+    def test_bulk_create_drivers_plan_limit(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner, driver_limit=1)
+
+        payload = {
+            "items": [
+                {"display_name": "Driver One"},
+                {"display_name": "Driver Two"},
+            ]
+        }
+
+        with override_user(owner):
+            response = client.post(f"/leagues/{league.id}/drivers", json=payload)
+
+        assert response.status_code == HTTPStatus.PAYMENT_REQUIRED
+        assert response.json()["error"]["code"] == "PLAN_LIMIT"
+
+    def test_update_driver_changes_name_and_team(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner)
+        team_alpha = create_team(database_session, league, "Alpha")
+        team_beta = create_team(database_session, league, "Beta")
+
+        driver = Driver(league_id=league.id, display_name="Driver One", team_id=team_alpha.id)
+        database_session.add(driver)
+        database_session.commit()
+        database_session.refresh(driver)
+
+        payload = {"display_name": "Driver Prime", "team_id": str(team_beta.id)}
+        with override_user(owner):
+            response = client.patch(f"/drivers/{driver.id}", json=payload)
+
+        assert response.status_code == HTTPStatus.OK, response.text
+        data = response.json()
+        assert data["display_name"] == "Driver Prime"
+        assert data["team_id"] == str(team_beta.id)
+        assert data["team_name"] == "Beta"
+
+    def test_update_driver_rejects_duplicate_name(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner)
+        driver1 = Driver(league_id=league.id, display_name="Driver One")
+        driver2 = Driver(league_id=league.id, display_name="Driver Two")
+        database_session.add_all([driver1, driver2])
+        database_session.commit()
+        database_session.refresh(driver2)
+
+        with override_user(owner):
+            response = client.patch(
+                f"/drivers/{driver2.id}",
+                json={"display_name": "Driver One"},
+            )
+
+        assert response.status_code == HTTPStatus.CONFLICT
+        assert response.json()["error"]["code"] == "DUPLICATE_DRIVER"
+
+    def test_delete_driver_requires_admin_role(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        steward = stub_user(database_session, "steward")
+        league = create_league_with_owner(database_session, owner)
+        membership = Membership(
+            league_id=league.id,
+            user_id=steward.id,
+            role=LeagueRole.STEWARD,
+        )
+        database_session.add(membership)
+        driver = Driver(league_id=league.id, display_name="Driver One")
+        database_session.add(driver)
+        database_session.commit()
+        database_session.refresh(driver)
+
+        with override_user(steward):
+            response = client.delete(f"/drivers/{driver.id}")
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert response.json()["error"]["code"] == "INSUFFICIENT_ROLE"
+
+    def test_list_drivers_returns_metadata(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner)
+        team = create_team(database_session, league, "Alpha")
+        driver = Driver(
+            league_id=league.id,
+            display_name="Driver One",
+            team_id=team.id,
+            discord_id="1234",
+        )
+        database_session.add(driver)
+        database_session.commit()
+
+        with override_user(owner):
+            response = client.get(f"/leagues/{league.id}/drivers")
+
+        assert response.status_code == HTTPStatus.OK, response.text
+        data = response.json()
+        assert data[0]["team_name"] == "Alpha"
+        assert data[0]["discord_id"] == "1234"

--- a/api/tests/test_teams.py
+++ b/api/tests/test_teams.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from http import HTTPStatus
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.settings import Settings, get_settings
+from app.db import Base
+from app.db.models import Driver, League, LeagueRole, Membership, Team, User
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.routes.auth import provide_discord_client
+
+SQLALCHEMY_DATABASE_URL = "sqlite+pysqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    future=True,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+)
+
+
+class StubDiscordClient:
+    def __init__(self) -> None:  # pragma: no cover
+        pass
+
+    async def exchange_code(self, *, code: str, code_verifier: str) -> dict[str, str]:
+        return {"access_token": "token"}
+
+    async def fetch_user(self, *, access_token: str) -> dict[str, str]:
+        return {
+            "id": "123",
+            "username": "Stub",
+            "avatar": None,
+            "email": None,
+        }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_database() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies() -> Generator[None, None, None]:
+    get_settings.cache_clear()
+
+    test_settings = Settings(
+        APP_ENV="test",
+        APP_URL="http://localhost:5173",
+        API_URL="http://localhost:8000",
+        DISCORD_CLIENT_ID="client",
+        DISCORD_CLIENT_SECRET="secret",  # noqa: S106
+        DISCORD_REDIRECT_URI="http://localhost:8000/auth/discord/callback",
+        JWT_SECRET="test-secret",  # noqa: S106
+        JWT_ACCESS_TTL_MIN=15,
+        JWT_REFRESH_TTL_DAYS=14,
+        CORS_ORIGINS="http://localhost:5173",
+    )
+
+    app.dependency_overrides[get_settings] = lambda: test_settings
+
+    def get_test_session() -> Generator[Session, None, None]:
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_session] = get_test_session
+    app.dependency_overrides[provide_discord_client] = lambda: StubDiscordClient()
+
+    yield
+
+    app.dependency_overrides.clear()
+
+
+@contextmanager
+def override_user(user: User) -> Generator[None, None, None]:
+    app.dependency_overrides[get_current_user] = lambda: user
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def database_session() -> Generator[Session, None, None]:
+    session = TestingSessionLocal()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def stub_user(session: Session, discord_id: str) -> User:
+    user = User(discord_id=discord_id, discord_username=discord_id)
+    session.add(user)
+    session.commit()
+    return user
+
+
+def create_league_with_owner(session: Session, owner: User) -> League:
+    league = League(
+        name="Test League",
+        slug=f"league-{uuid4().hex[:8]}",
+        owner_id=owner.id,
+    )
+    session.add(league)
+    session.commit()
+    session.refresh(league)
+
+    membership = Membership(league_id=league.id, user_id=owner.id, role=LeagueRole.OWNER)
+    session.add(membership)
+    session.commit()
+    return league
+
+
+def create_team(session: Session, league: League, name: str) -> Team:
+    team = Team(league_id=league.id, name=name)
+    session.add(team)
+    session.commit()
+    session.refresh(team)
+    return team
+
+
+class TestTeamRoutes:
+    def test_create_team_success(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner)
+
+        with override_user(owner):
+            response = client.post(
+                f"/leagues/{league.id}/teams",
+                json={"name": "Alpha"},
+            )
+
+        assert response.status_code == HTTPStatus.CREATED, response.text
+        data = response.json()
+        assert data["name"] == "Alpha"
+        assert data["driver_count"] == 0
+
+    def test_create_team_duplicate_name(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner)
+        create_team(database_session, league, "Alpha")
+
+        with override_user(owner):
+            response = client.post(
+                f"/leagues/{league.id}/teams",
+                json={"name": "Alpha"},
+            )
+
+        assert response.status_code == HTTPStatus.CONFLICT
+        assert response.json()["error"]["code"] == "DUPLICATE_TEAM"
+
+    def test_update_team_changes_name(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner)
+        team = create_team(database_session, league, "Alpha")
+
+        with override_user(owner):
+            response = client.patch(
+                f"/teams/{team.id}",
+                json={"name": "Beta"},
+            )
+
+        assert response.status_code == HTTPStatus.OK, response.text
+        assert response.json()["name"] == "Beta"
+
+    def test_delete_team_reassigns_drivers(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner)
+        team = create_team(database_session, league, "Alpha")
+        driver = Driver(league_id=league.id, display_name="Driver One", team_id=team.id)
+        database_session.add(driver)
+        database_session.commit()
+        database_session.refresh(driver)
+        driver_id = driver.id
+
+        with override_user(owner):
+            response = client.delete(f"/teams/{team.id}")
+
+        assert response.status_code == HTTPStatus.NO_CONTENT, response.text
+        database_session.expire_all()
+        reloaded = database_session.get(Driver, driver_id)
+        assert reloaded is not None
+        assert reloaded.team_id is None
+
+    def test_list_teams_includes_driver_counts(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner)
+        team_alpha = create_team(database_session, league, "Alpha")
+        team_beta = create_team(database_session, league, "Beta")
+        database_session.add_all(
+            [
+                Driver(league_id=league.id, display_name="Driver One", team_id=team_alpha.id),
+                Driver(league_id=league.id, display_name="Driver Two", team_id=team_alpha.id),
+                Driver(league_id=league.id, display_name="Driver Three", team_id=team_beta.id),
+            ]
+        )
+        database_session.commit()
+
+        with override_user(owner):
+            response = client.get(f"/leagues/{league.id}/teams")
+
+        assert response.status_code == HTTPStatus.OK, response.text
+        data = response.json()
+        counts = {item["name"]: item["driver_count"] for item in data}
+        assert counts["Alpha"] == 2
+        assert counts["Beta"] == 1
+
+    def test_modify_team_requires_admin(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        steward = stub_user(database_session, "steward")
+        league = create_league_with_owner(database_session, owner)
+        team = create_team(database_session, league, "Alpha")
+        membership = Membership(
+            league_id=league.id,
+            user_id=steward.id,
+            role=LeagueRole.STEWARD,
+        )
+        database_session.add(membership)
+        database_session.commit()
+
+        with override_user(steward):
+            response = client.patch(f"/teams/{team.id}", json={"name": "Beta"})
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert response.json()["error"]["code"] == "INSUFFICIENT_ROLE"
+

--- a/docs/AppPBIs.md
+++ b/docs/AppPBIs.md
@@ -50,7 +50,7 @@ Acceptance Criteria:
 Dependencies: PBI-004
 Branch: pbi/005-rbac-memberships
 
-## PBI-006 - League Management API
+## PBI-006 - League Management API (Still needs to be completed)
 Summary: Provide CRUD operations for leagues including default season creation and soft delete.
 Scope: Backend
 Acceptance Criteria:


### PR DESCRIPTION
Implements league-scoped drivers/teams endpoints with bulk create, RBAC, duplicates, plan-limit checks, and soft reassignment on delete.
Adds shared error envelope helper plus RBAC utilities reused across routers.
Extends backend test suite with driver/team coverage; python -m pytest now runs clean (29 passing).