### PR TITLE
feat(api): add seasons and points scheme management (PBI-008)

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from app.core.settings import get_settings
-from app.routes import auth, drivers, leagues, memberships, teams
+from app.routes import auth, drivers, leagues, memberships, points, seasons, teams
 
 settings = get_settings()
 
@@ -27,6 +27,8 @@ app.include_router(auth.router)
 app.include_router(leagues.router)
 app.include_router(memberships.router)
 app.include_router(drivers.router)
+app.include_router(seasons.router)
+app.include_router(points.router)
 app.include_router(teams.router)
 
 

--- a/api/app/routes/__init__.py
+++ b/api/app/routes/__init__.py
@@ -1,5 +1,5 @@
 """API route modules."""
 
-from . import auth, drivers, leagues, memberships, teams
+from . import auth, drivers, leagues, memberships, points, seasons, teams
 
-__all__ = ["auth", "drivers", "leagues", "memberships", "teams"]
+__all__ = ["auth", "drivers", "leagues", "memberships", "points", "seasons", "teams"]

--- a/api/app/routes/points.py
+++ b/api/app/routes/points.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.errors import api_error
+from app.db.models import Event, League, LeagueRole, PointsRule, PointsScheme, Season, User
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.schemas.points import (
+    PointsRuleInput,
+    PointsRuleRead,
+    PointsSchemeCreate,
+    PointsSchemeRead,
+    PointsSchemeUpdate,
+)
+from app.services.points import default_points_entries, normalize_points_entries
+from app.services.rbac import require_membership, require_role_at_least
+
+router = APIRouter(tags=["points"])
+
+SessionDep = Annotated[Session, Depends(get_session)]
+CurrentUserDep = Annotated[User, Depends(get_current_user)]
+
+
+DEFAULT_RULE_LIMIT = 20
+
+
+def _season_predicate(season_id: UUID | None):
+    return PointsScheme.season_id.is_(None) if season_id is None else PointsScheme.season_id == season_id
+
+
+def _get_league(session: Session, league_id: UUID) -> League:
+    league = session.get(League, league_id)
+    if league is None or league.is_deleted:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="LEAGUE_NOT_FOUND",
+            message="League not found",
+        )
+    return league
+
+
+def _scheme_to_read(scheme: PointsScheme) -> PointsSchemeRead:
+    return PointsSchemeRead(
+        id=scheme.id,
+        league_id=scheme.league_id,
+        season_id=scheme.season_id,
+        name=scheme.name,
+        is_default=scheme.is_default,
+        rules=[
+            PointsRuleRead.model_validate(rule)
+            for rule in sorted(scheme.rules, key=lambda r: r.position)
+        ],
+    )
+
+
+def _validate_rules(rules: list[PointsRuleInput] | None) -> list[tuple[int, int]]:
+    entries: list[tuple[int, int]]
+    if not rules:
+        entries = default_points_entries()
+    else:
+        raw_entries = [(item.position, item.points) for item in rules]
+        try:
+            entries = normalize_points_entries(raw_entries)
+        except ValueError as exc:
+            raise api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="DUPLICATE_POSITION",
+                message="Points table contains duplicate positions",
+            ) from exc
+    if len(entries) > DEFAULT_RULE_LIMIT:
+        raise api_error(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code="TOO_MANY_POSITIONS",
+            message="Points table exceeds supported positions",
+        )
+    return entries
+
+
+def _ensure_season(session: Session, *, league_id: UUID, season_id: UUID | None) -> UUID | None:
+    if season_id is None:
+        return None
+    season = session.get(Season, season_id)
+    if season is None or season.league_id != league_id:
+        raise api_error(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code="INVALID_SEASON",
+            message="Season does not belong to this league",
+            field="season_id",
+        )
+    return season_id
+
+
+def _set_rules_for_scheme(scheme: PointsScheme, entries: list[tuple[int, int]]) -> None:
+    scheme.rules[:] = [PointsRule(position=position, points=points) for position, points in entries]
+
+
+
+@router.get(
+    "/leagues/{league_id}/points-schemes",
+    response_model=list[PointsSchemeRead],
+)
+async def list_points_schemes(
+    league_id: UUID,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> list[PointsSchemeRead]:
+    _get_league(session, league_id)
+    require_membership(session, league_id=league_id, user_id=current_user.id)
+
+    schemes = (
+        session.execute(
+            select(PointsScheme)
+            .options(joinedload(PointsScheme.rules))
+            .where(PointsScheme.league_id == league_id)
+            .order_by(PointsScheme.name)
+        )
+        .scalars()
+        .all()
+    )
+    return [_scheme_to_read(scheme) for scheme in schemes]
+
+
+@router.post(
+    "/leagues/{league_id}/points-schemes",
+    response_model=PointsSchemeRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_points_scheme(
+    league_id: UUID,
+    payload: PointsSchemeCreate,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> PointsSchemeRead:
+    _get_league(session, league_id)
+    membership = require_membership(session, league_id=league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    name = payload.name.strip()
+    if not name:
+        raise api_error(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code="INVALID_NAME",
+            message="Points scheme name is required",
+            field="name",
+        )
+
+    season_id = _ensure_season(session, league_id=league_id, season_id=payload.season_id)
+    entries = _validate_rules(payload.rules)
+
+    scheme = PointsScheme(
+        league_id=league_id,
+        season_id=season_id,
+        name=name,
+        is_default=bool(payload.is_default),
+    )
+    _set_rules_for_scheme(scheme, entries)
+    session.add(scheme)
+    session.flush()
+
+    if scheme.is_default:
+        session.execute(
+            update(PointsScheme)
+            .where(
+                PointsScheme.league_id == league_id,
+                _season_predicate(season_id),
+                PointsScheme.id != scheme.id,
+            )
+            .values(is_default=False)
+        )
+
+    session.commit()
+    session.refresh(scheme)
+    return _scheme_to_read(scheme)
+
+
+@router.patch("/points-schemes/{scheme_id}", response_model=PointsSchemeRead)
+async def update_points_scheme(
+    scheme_id: UUID,
+    payload: PointsSchemeUpdate,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> PointsSchemeRead:
+    scheme = (
+        session.execute(
+            select(PointsScheme)
+            .options(joinedload(PointsScheme.rules))
+            .where(PointsScheme.id == scheme_id)
+        )
+        .scalars()
+        .first()
+    )
+    if scheme is None:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="POINTS_SCHEME_NOT_FOUND",
+            message="Points scheme not found",
+        )
+
+    membership = require_membership(session, league_id=scheme.league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    update_data = payload.model_dump(exclude_unset=True)
+
+    if "name" in update_data and update_data["name"] is not None:
+        new_name = update_data["name"].strip()
+        if not new_name:
+            raise api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="INVALID_NAME",
+                message="Points scheme name is required",
+                field="name",
+            )
+        scheme.name = new_name
+
+    if "season_id" in update_data:
+        season_id = _ensure_season(
+            session, league_id=scheme.league_id, season_id=update_data["season_id"]
+        )
+        scheme.season_id = season_id
+
+    if "rules" in update_data and update_data["rules"] is not None:
+        entries = _validate_rules(update_data["rules"])
+        _set_rules_for_scheme(scheme, entries)
+
+    if "is_default" in update_data and update_data["is_default"] is not None:
+        make_default = bool(update_data["is_default"])
+        if make_default:
+            session.execute(
+                update(PointsScheme)
+                .where(
+                    PointsScheme.league_id == scheme.league_id,
+                    _season_predicate(scheme.season_id),
+                    PointsScheme.id != scheme.id,
+                )
+                .values(is_default=False)
+            )
+            scheme.is_default = True
+        else:
+            other_defaults = session.execute(
+                select(PointsScheme).where(
+                    PointsScheme.league_id == scheme.league_id,
+                    _season_predicate(scheme.season_id),
+                    PointsScheme.id != scheme.id,
+                    PointsScheme.is_default.is_(True),
+                )
+            ).scalars().all()
+            if not other_defaults:
+                raise api_error(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    code="MISSING_DEFAULT_SCHEME",
+                    message="At least one default scheme is required per season",
+                )
+            scheme.is_default = False
+
+    session.commit()
+    session.refresh(scheme)
+    return _scheme_to_read(scheme)
+
+
+@router.delete("/points-schemes/{scheme_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_points_scheme(
+    scheme_id: UUID,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> Response:
+    scheme = (
+        session.execute(
+            select(PointsScheme)
+            .options(joinedload(PointsScheme.rules))
+            .where(PointsScheme.id == scheme_id)
+        )
+        .scalars()
+        .first()
+    )
+    if scheme is None:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="POINTS_SCHEME_NOT_FOUND",
+            message="Points scheme not found",
+        )
+
+    membership = require_membership(session, league_id=scheme.league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    if scheme.is_default:
+        related_events = session.execute(
+            select(Event.id).where(Event.season_id == scheme.season_id)
+        ).first()
+        if related_events is not None:
+            raise api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="SCHEME_IN_USE",
+                message="Cannot delete default scheme while events exist for the season",
+            )
+
+        other_scheme_exists = session.execute(
+            select(PointsScheme.id).where(
+                PointsScheme.league_id == scheme.league_id,
+                PointsScheme.id != scheme.id,
+            )
+        ).first()
+        if not other_scheme_exists:
+            raise api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="MISSING_DEFAULT_SCHEME",
+                message="At least one points scheme must remain",
+            )
+
+    session.delete(scheme)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/routes/seasons.py
+++ b/api/app/routes/seasons.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy import func, select, update
+from sqlalchemy.orm import Session
+
+from app.core.errors import api_error
+from app.db.models import League, LeagueRole, Season, User
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.schemas.seasons import SeasonCreate, SeasonRead, SeasonUpdate
+from app.services.rbac import require_membership, require_role_at_least
+
+router = APIRouter(tags=["seasons"])
+
+SessionDep = Annotated[Session, Depends(get_session)]
+CurrentUserDep = Annotated[User, Depends(get_current_user)]
+
+
+def _get_league(session: Session, league_id: UUID) -> League:
+    league = session.get(League, league_id)
+    if league is None or league.is_deleted:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="LEAGUE_NOT_FOUND",
+            message="League not found",
+        )
+    return league
+
+
+def _season_to_read(season: Season) -> SeasonRead:
+    return SeasonRead(
+        id=season.id,
+        league_id=season.league_id,
+        name=season.name,
+        is_active=season.is_active,
+    )
+
+
+@router.get("/leagues/{league_id}/seasons", response_model=list[SeasonRead])
+async def list_seasons(
+    league_id: UUID,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> list[SeasonRead]:
+    _get_league(session, league_id)
+    require_membership(session, league_id=league_id, user_id=current_user.id)
+
+    seasons = (
+        session.execute(
+            select(Season).where(Season.league_id == league_id).order_by(Season.name)
+        )
+        .scalars()
+        .all()
+    )
+    return [_season_to_read(season) for season in seasons]
+
+
+@router.post(
+    "/leagues/{league_id}/seasons",
+    response_model=SeasonRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_season(
+    league_id: UUID,
+    payload: SeasonCreate,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> SeasonRead:
+    _get_league(session, league_id)
+    membership = require_membership(session, league_id=league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    name = payload.name.strip()
+    if not name:
+        raise api_error(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code="INVALID_NAME",
+            message="Season name is required",
+            field="name",
+        )
+
+    desired_active = bool(payload.is_active)
+
+    season = Season(league_id=league_id, name=name, is_active=desired_active)
+
+    if desired_active:
+        session.execute(
+            update(Season)
+            .where(Season.league_id == league_id, Season.is_active.is_(True))
+            .values(is_active=False)
+        )
+    else:
+        active_count = session.execute(
+            select(func.count(Season.id)).where(
+                Season.league_id == league_id, Season.is_active.is_(True)
+            )
+        ).scalar_one()
+        if active_count == 0:
+            season.is_active = True
+
+    session.add(season)
+    session.commit()
+    session.refresh(season)
+    return _season_to_read(season)
+
+
+@router.patch("/seasons/{season_id}", response_model=SeasonRead)
+async def update_season(
+    season_id: UUID,
+    payload: SeasonUpdate,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+) -> SeasonRead:
+    season = session.get(Season, season_id)
+    if season is None:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="SEASON_NOT_FOUND",
+            message="Season not found",
+        )
+
+    membership = require_membership(session, league_id=season.league_id, user_id=current_user.id)
+    require_role_at_least(membership, minimum=LeagueRole.ADMIN)
+
+    update_data = payload.model_dump(exclude_unset=True)
+
+    if "name" in update_data and update_data["name"] is not None:
+        new_name = update_data["name"].strip()
+        if not new_name:
+            raise api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="INVALID_NAME",
+                message="Season name is required",
+                field="name",
+            )
+        season.name = new_name
+
+    if "is_active" in update_data and update_data["is_active"] is not None:
+        desired_active = bool(update_data["is_active"])
+        if desired_active:
+            session.execute(
+                update(Season)
+                .where(Season.league_id == season.league_id, Season.is_active.is_(True), Season.id != season.id)
+                .values(is_active=False)
+            )
+            season.is_active = True
+        else:
+            other_active = session.execute(
+                select(func.count(Season.id)).where(
+                    Season.league_id == season.league_id,
+                    Season.is_active.is_(True),
+                    Season.id != season.id,
+                )
+            ).scalar_one()
+            if other_active == 0:
+                raise api_error(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    code="LAST_ACTIVE_SEASON",
+                    message="At least one season must remain active",
+                )
+            season.is_active = False
+
+    session.commit()
+    session.refresh(season)
+    return _season_to_read(season)

--- a/api/app/schemas/points.py
+++ b/api/app/schemas/points.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import List
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class PointsRuleInput(BaseModel):
+    position: int = Field(gt=0)
+    points: int = Field(ge=0)
+
+
+class PointsRuleRead(BaseModel):
+    id: UUID
+    position: int
+    points: int
+
+    class Config:
+        from_attributes = True
+
+
+class PointsSchemeCreate(BaseModel):
+    name: str = Field(min_length=1)
+    season_id: UUID | None = None
+    is_default: bool | None = False
+    rules: List[PointsRuleInput] | None = None
+
+
+class PointsSchemeUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1)
+    season_id: UUID | None = None
+    is_default: bool | None = None
+    rules: List[PointsRuleInput] | None = None
+
+
+class PointsSchemeRead(BaseModel):
+    id: UUID
+    league_id: UUID
+    season_id: UUID | None
+    name: str
+    is_default: bool
+    rules: list[PointsRuleRead]
+
+    class Config:
+        from_attributes = True

--- a/api/app/schemas/seasons.py
+++ b/api/app/schemas/seasons.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class SeasonCreate(BaseModel):
+    name: str = Field(min_length=1)
+    is_active: bool | None = False
+
+
+class SeasonUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1)
+    is_active: bool | None = None
+
+
+class SeasonRead(BaseModel):
+    id: UUID
+    league_id: UUID
+    name: str
+    is_active: bool
+
+    class Config:
+        from_attributes = True

--- a/api/app/services/points.py
+++ b/api/app/services/points.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+DEFAULT_F1_POINTS: dict[int, int] = {
+    1: 25,
+    2: 18,
+    3: 15,
+    4: 12,
+    5: 10,
+    6: 8,
+    7: 6,
+    8: 4,
+    9: 2,
+    10: 1,
+}
+
+
+def default_points_entries() -> list[tuple[int, int]]:
+    """Return the default F1 points mapping as (position, points) pairs."""
+    return sorted(DEFAULT_F1_POINTS.items(), key=lambda item: item[0])
+
+
+def normalize_points_entries(entries: Iterable[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Normalize user-provided point entries, ensuring sorted unique positions."""
+    seen: set[int] = set()
+    normalized: list[tuple[int, int]] = []
+    for position, points in entries:
+        if position in seen:
+            raise ValueError("Duplicate position in points map")
+        seen.add(position)
+        normalized.append((position, points))
+    normalized.sort(key=lambda item: item[0])
+    return normalized

--- a/api/tests/test_points.py
+++ b/api/tests/test_points.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from http import HTTPStatus
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.settings import Settings, get_settings
+from app.db import Base
+from app.db.models import Event, League, LeagueRole, Membership, PointsScheme, Season, User
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.routes.auth import provide_discord_client
+
+SQLALCHEMY_DATABASE_URL = "sqlite+pysqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    future=True,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+)
+
+
+class StubDiscordClient:
+    def __init__(self) -> None:  # pragma: no cover
+        pass
+
+    async def exchange_code(self, *, code: str, code_verifier: str) -> dict[str, str]:
+        return {"access_token": "token"}
+
+    async def fetch_user(self, *, access_token: str) -> dict[str, str]:
+        return {
+            "id": "123",
+            "username": "Stub",
+            "avatar": None,
+            "email": None,
+        }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_database() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies() -> Generator[None, None, None]:
+    get_settings.cache_clear()
+
+    test_settings = Settings(
+        APP_ENV="test",
+        APP_URL="http://localhost:5173",
+        API_URL="http://localhost:8000",
+        DISCORD_CLIENT_ID="client",
+        DISCORD_CLIENT_SECRET="secret",  # noqa: S106
+        DISCORD_REDIRECT_URI="http://localhost:8000/auth/discord/callback",
+        JWT_SECRET="test-secret",  # noqa: S106
+        JWT_ACCESS_TTL_MIN=15,
+        JWT_REFRESH_TTL_DAYS=14,
+        CORS_ORIGINS="http://localhost:5173",
+    )
+
+    app.dependency_overrides[get_settings] = lambda: test_settings
+
+    def get_test_session() -> Generator[Session, None, None]:
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_session] = get_test_session
+    app.dependency_overrides[provide_discord_client] = lambda: StubDiscordClient()
+
+    yield
+
+    app.dependency_overrides.clear()
+
+
+@contextmanager
+def override_user(user: User) -> Generator[None, None, None]:
+    app.dependency_overrides[get_current_user] = lambda: user
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def database_session() -> Generator[Session, None, None]:
+    session = TestingSessionLocal()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def stub_user(session: Session, discord_id: str) -> User:
+    user = User(discord_id=discord_id, discord_username=discord_id)
+    session.add(user)
+    session.commit()
+    return user
+
+
+def create_league_with_owner(session: Session, owner: User) -> tuple[League, Season]:
+    league = League(
+        name="Test League",
+        slug=f"league-{uuid4().hex[:8]}",
+        owner_id=owner.id,
+    )
+    season = Season(league=league, name="Initial Season", is_active=True)
+    membership = Membership(league=league, user_id=owner.id, role=LeagueRole.OWNER)
+    session.add_all([league, season, membership])
+    session.commit()
+    session.refresh(league)
+    session.refresh(season)
+    return league, season
+
+
+def create_event(session: Session, league: League, season: Season) -> Event:
+    event = Event(
+        league_id=league.id,
+        season_id=season.id,
+        name="Race 1",
+        track="Spa",
+        start_time=datetime.now(timezone.utc),
+        status="SCHEDULED",
+    )
+    session.add(event)
+    session.commit()
+    session.refresh(event)
+    return event
+
+
+class TestPointsSchemeRoutes:
+    def test_create_points_scheme_uses_default_rules(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, season = create_league_with_owner(database_session, owner)
+
+        payload = {"name": "F1 Default", "season_id": str(season.id), "is_default": True}
+        with override_user(owner):
+            response = client.post(f"/leagues/{league.id}/points-schemes", json=payload)
+
+        assert response.status_code == HTTPStatus.CREATED, response.text
+        data = response.json()
+        assert data["name"] == "F1 Default"
+        assert len(data["rules"]) == 10
+        assert data["rules"][0]["points"] == 25
+
+    def test_create_points_scheme_custom_rules(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, season = create_league_with_owner(database_session, owner)
+
+        rules = [{"position": 1, "points": 10}, {"position": 2, "points": 6}]
+        payload = {
+            "name": "Sprint",
+            "season_id": str(season.id),
+            "is_default": False,
+            "rules": rules,
+        }
+        with override_user(owner):
+            response = client.post(f"/leagues/{league.id}/points-schemes", json=payload)
+
+        assert response.status_code == HTTPStatus.CREATED, response.text
+        data = response.json()
+        assert [rule["points"] for rule in data["rules"]] == [10, 6]
+
+    def test_set_scheme_default_resets_previous(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, season = create_league_with_owner(database_session, owner)
+
+        with override_user(owner):
+            first = client.post(
+                f"/leagues/{league.id}/points-schemes",
+                json={"name": "Primary", "season_id": str(season.id), "is_default": True},
+            )
+            assert first.status_code == HTTPStatus.CREATED
+            second = client.post(
+                f"/leagues/{league.id}/points-schemes",
+                json={"name": "Alternate", "season_id": str(season.id), "is_default": False},
+            )
+            assert second.status_code == HTTPStatus.CREATED
+
+        scheme_id = UUID(second.json()["id"])
+        with override_user(owner):
+            response = client.patch(
+                f"/points-schemes/{scheme_id}",
+                json={"is_default": True},
+            )
+
+        assert response.status_code == HTTPStatus.OK
+        defaults = (
+            database_session.execute(
+                select(PointsScheme).where(
+                    PointsScheme.league_id == league.id,
+                    PointsScheme.season_id == season.id,
+                )
+            )
+            .scalars()
+            .all()
+        )
+        default_flags = {scheme.name: scheme.is_default for scheme in defaults}
+        assert default_flags == {"Primary": False, "Alternate": True}
+
+    def test_delete_default_scheme_blocked_when_events_exist(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, season = create_league_with_owner(database_session, owner)
+        create_event(database_session, league, season)
+
+        with override_user(owner):
+            response = client.post(
+                f"/leagues/{league.id}/points-schemes",
+                json={"name": "Protected", "season_id": str(season.id), "is_default": True},
+            )
+        assert response.status_code == HTTPStatus.CREATED
+        scheme_id = response.json()["id"]
+
+        with override_user(owner):
+            delete_response = client.delete(f"/points-schemes/{scheme_id}")
+
+        assert delete_response.status_code == HTTPStatus.BAD_REQUEST
+        assert delete_response.json()["error"]["code"] == "SCHEME_IN_USE"
+
+    def test_duplicate_positions_rejected(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, season = create_league_with_owner(database_session, owner)
+        payload = {
+            "name": "Invalid",
+            "season_id": str(season.id),
+            "is_default": False,
+            "rules": [
+                {"position": 1, "points": 10},
+                {"position": 1, "points": 5},
+            ],
+        }
+
+        with override_user(owner):
+            response = client.post(f"/leagues/{league.id}/points-schemes", json=payload)
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.json()["error"]["code"] == "DUPLICATE_POSITION"

--- a/api/tests/test_seasons.py
+++ b/api/tests/test_seasons.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from http import HTTPStatus
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.settings import Settings, get_settings
+from app.db import Base
+from app.db.models import League, LeagueRole, Membership, Season, User
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.routes.auth import provide_discord_client
+
+SQLALCHEMY_DATABASE_URL = "sqlite+pysqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    future=True,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+)
+
+
+class StubDiscordClient:
+    def __init__(self) -> None:  # pragma: no cover
+        pass
+
+    async def exchange_code(self, *, code: str, code_verifier: str) -> dict[str, str]:
+        return {"access_token": "token"}
+
+    async def fetch_user(self, *, access_token: str) -> dict[str, str]:
+        return {
+            "id": "123",
+            "username": "Stub",
+            "avatar": None,
+            "email": None,
+        }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_database() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies() -> Generator[None, None, None]:
+    get_settings.cache_clear()
+
+    test_settings = Settings(
+        APP_ENV="test",
+        APP_URL="http://localhost:5173",
+        API_URL="http://localhost:8000",
+        DISCORD_CLIENT_ID="client",
+        DISCORD_CLIENT_SECRET="secret",  # noqa: S106
+        DISCORD_REDIRECT_URI="http://localhost:8000/auth/discord/callback",
+        JWT_SECRET="test-secret",  # noqa: S106
+        JWT_ACCESS_TTL_MIN=15,
+        JWT_REFRESH_TTL_DAYS=14,
+        CORS_ORIGINS="http://localhost:5173",
+    )
+
+    app.dependency_overrides[get_settings] = lambda: test_settings
+
+    def get_test_session() -> Generator[Session, None, None]:
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_session] = get_test_session
+    app.dependency_overrides[provide_discord_client] = lambda: StubDiscordClient()
+
+    yield
+
+    app.dependency_overrides.clear()
+
+
+@contextmanager
+def override_user(user: User) -> Generator[None, None, None]:
+    app.dependency_overrides[get_current_user] = lambda: user
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def database_session() -> Generator[Session, None, None]:
+    session = TestingSessionLocal()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def stub_user(session: Session, discord_id: str) -> User:
+    user = User(discord_id=discord_id, discord_username=discord_id)
+    session.add(user)
+    session.commit()
+    return user
+
+
+def create_league_with_owner(session: Session, owner: User) -> tuple[League, Season]:
+    league = League(
+        name="Test League",
+        slug=f"league-{uuid4().hex[:8]}",
+        owner_id=owner.id,
+    )
+    season = Season(league=league, name="Initial Season", is_active=True)
+    membership = Membership(league=league, user_id=owner.id, role=LeagueRole.OWNER)
+    session.add_all([league, season, membership])
+    session.commit()
+    session.refresh(league)
+    session.refresh(season)
+    return league, season
+
+
+class TestSeasonRoutes:
+    def test_create_season_inactive_preserves_existing_active(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, active_season = create_league_with_owner(database_session, owner)
+
+        payload = {"name": "Winter Series", "is_active": False}
+        with override_user(owner):
+            response = client.post(f"/leagues/{league.id}/seasons", json=payload)
+
+        assert response.status_code == HTTPStatus.CREATED, response.text
+        data = response.json()
+        assert data["name"] == "Winter Series"
+        assert data["is_active"] is False
+
+        refreshed_active = database_session.get(Season, active_season.id)
+        assert refreshed_active.is_active is True
+
+    def test_create_season_active_swaps_previous(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, active_season = create_league_with_owner(database_session, owner)
+
+        payload = {"name": "Spring Series", "is_active": True}
+        with override_user(owner):
+            response = client.post(f"/leagues/{league.id}/seasons", json=payload)
+
+        assert response.status_code == HTTPStatus.CREATED, response.text
+        new_season_id = UUID(response.json()["id"])
+
+        database_session.expire_all()
+        old = database_session.get(Season, active_season.id)
+        new = database_session.get(Season, new_season_id)
+        assert old.is_active is False
+        assert new.is_active is True
+
+    def test_update_season_activate(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, active_season = create_league_with_owner(database_session, owner)
+
+        inactive_season = Season(league_id=league.id, name="Off Season", is_active=False)
+        database_session.add(inactive_season)
+        database_session.commit()
+        database_session.refresh(inactive_season)
+
+        with override_user(owner):
+            response = client.patch(
+                f"/seasons/{inactive_season.id}",
+                json={"is_active": True},
+            )
+
+        assert response.status_code == HTTPStatus.OK, response.text
+        database_session.refresh(active_season)
+        database_session.refresh(inactive_season)
+        assert inactive_season.is_active is True
+        assert active_season.is_active is False
+
+    def test_update_season_cannot_deactivate_last_active(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, active_season = create_league_with_owner(database_session, owner)
+
+        with override_user(owner):
+            response = client.patch(
+                f"/seasons/{active_season.id}",
+                json={"is_active": False},
+            )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.json()["error"]["code"] == "LAST_ACTIVE_SEASON"
+
+    def test_list_seasons_returns_all(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, _ = create_league_with_owner(database_session, owner)
+        database_session.add(Season(league_id=league.id, name="Second Season", is_active=False))
+        database_session.commit()
+
+        with override_user(owner):
+            response = client.get(f"/leagues/{league.id}/seasons")
+
+        assert response.status_code == HTTPStatus.OK
+        names = {item["name"] for item in response.json()}
+        assert names == {"Initial Season", "Second Season"}


### PR DESCRIPTION
Adds season endpoints with single-active enforcement and validation to block removing the last active season.
Implements points scheme CRUD, default F1 seeding, duplicate/season ownership checks, and safeguards against deleting in-use defaults.
Updates router wiring plus new unit tests; python -m pytest passes (39 tests).