### PR TITLE
feat(api): implement standings service cache (PBI-012)

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 from fastapi import FastAPI, Request
 from fastapi.exception_handlers import http_exception_handler
@@ -7,7 +7,18 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from app.core.settings import get_settings
-from app.routes import auth, drivers, events, leagues, memberships, points, results, seasons, teams
+from app.routes import (
+    auth,
+    drivers,
+    events,
+    leagues,
+    memberships,
+    points,
+    results,
+    seasons,
+    standings,
+    teams,
+)
 
 settings = get_settings()
 
@@ -29,6 +40,7 @@ app.include_router(memberships.router)
 app.include_router(drivers.router)
 app.include_router(events.router)
 app.include_router(results.router)
+app.include_router(standings.router)
 app.include_router(seasons.router)
 app.include_router(points.router)
 app.include_router(teams.router)

--- a/api/app/routes/__init__.py
+++ b/api/app/routes/__init__.py
@@ -1,6 +1,17 @@
-"""API route modules."""
+﻿"""API route modules."""
 
-from . import auth, drivers, events, leagues, memberships, points, results, seasons, teams
+from . import (
+    auth,
+    drivers,
+    events,
+    leagues,
+    memberships,
+    points,
+    results,
+    seasons,
+    standings,
+    teams,
+)
 
 __all__ = [
     "auth",
@@ -11,5 +22,6 @@ __all__ = [
     "points",
     "results",
     "seasons",
+    "standings",
     "teams",
 ]

--- a/api/app/routes/results.py
+++ b/api/app/routes/results.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import json
 import logging
@@ -30,6 +30,7 @@ from app.schemas.results import EventResultsRead, ResultEntryRead, ResultSubmiss
 from app.services.idempotency import IdempotencyConfig, get_idempotency_service
 from app.services.points import build_points_map, default_points_entries
 from app.services.rbac import require_membership, require_role_at_least
+from app.services.standings import StandingsCacheConfig, get_standings_cache
 
 try:
     from worker.jobs import standings
@@ -281,6 +282,8 @@ async def submit_results(
         raise
 
     session.refresh(event)
+    cache = get_standings_cache(StandingsCacheConfig(redis_url=settings.redis_url))
+    cache.invalidate(league_id=event.league_id, season_id=event.season_id)
     refreshed_results = (
         session.execute(
             select(Result).where(Result.event_id == event.id).order_by(Result.finish_position)
@@ -335,5 +338,6 @@ async def read_results(
         .all()
     )
     return _build_response(event, results)
+
 
 

--- a/api/app/routes/standings.py
+++ b/api/app/routes/standings.py
@@ -1,0 +1,147 @@
+﻿from __future__ import annotations
+
+from typing import Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import api_error
+from app.core.settings import Settings, get_settings
+from app.db.models import League, Season, User
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.schemas.standings import SeasonStandingsRead, StandingsItem
+from app.services.rbac import require_membership
+from app.services.standings import (
+    StandingsCacheConfig,
+    calculate_standings,
+    get_standings_cache,
+)
+
+router = APIRouter(tags=["standings"])
+
+SessionDep = Annotated[Session, Depends(get_session)]
+CurrentUserDep = Annotated[User, Depends(get_current_user)]
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+
+def _get_league(session: Session, league_id: UUID) -> League:
+    league = session.get(League, league_id)
+    if league is None or league.is_deleted:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="LEAGUE_NOT_FOUND",
+            message="League not found",
+        )
+    return league
+
+
+def _resolve_season(
+    session: Session,
+    *,
+    league_id: UUID,
+    season_id: UUID | None,
+) -> UUID | None:
+    if season_id is not None:
+        season = session.get(Season, season_id)
+        if season is None or season.league_id != league_id:
+            raise api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="INVALID_SEASON",
+                message="Season does not belong to this league",
+                field="season_id",
+            )
+        return season.id
+
+    active = (
+        session.execute(
+            select(Season.id).where(Season.league_id == league_id, Season.is_active.is_(True))
+        )
+        .scalars()
+        .first()
+    )
+    if active is None:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="SEASON_NOT_FOUND",
+            message="No active season configured for league",
+        )
+    return active
+
+
+def _serialize_response(response: SeasonStandingsRead) -> dict[str, Any]:
+    return {
+        "league_id": str(response.league_id),
+        "season_id": str(response.season_id) if response.season_id is not None else None,
+        "items": [
+            {
+                "driver_id": str(item.driver_id),
+                "display_name": item.display_name,
+                "points": item.points,
+                "wins": item.wins,
+                "best_finish": item.best_finish,
+            }
+            for item in response.items
+        ],
+    }
+
+
+def _deserialize_payload(payload: dict[str, Any]) -> SeasonStandingsRead:
+    season_value = payload.get("season_id")
+    return SeasonStandingsRead(
+        league_id=UUID(payload["league_id"]),
+        season_id=UUID(season_value) if season_value else None,
+        items=[
+            StandingsItem(
+                driver_id=UUID(item["driver_id"]),
+                display_name=item["display_name"],
+                points=int(item["points"]),
+                wins=int(item["wins"]),
+                best_finish=int(item["best_finish"]) if item["best_finish"] is not None else None,
+            )
+            for item in payload.get("items", [])
+        ],
+    )
+
+
+@router.get("/leagues/{league_id}/standings", response_model=SeasonStandingsRead)
+async def read_standings(
+    league_id: UUID,
+    session: SessionDep,
+    current_user: CurrentUserDep,
+    settings: SettingsDep,
+    season_id: UUID | None = Query(default=None, alias="seasonId"),
+) -> SeasonStandingsRead:
+    _get_league(session, league_id)
+    require_membership(session, league_id=league_id, user_id=current_user.id)
+
+    resolved_season_id = _resolve_season(
+        session,
+        league_id=league_id,
+        season_id=season_id,
+    )
+
+    cache = get_standings_cache(StandingsCacheConfig(redis_url=settings.redis_url))
+    cached_payload = cache.get(league_id=league_id, season_id=resolved_season_id)
+    if cached_payload is not None:
+        return _deserialize_payload(cached_payload)
+
+    raw_items = calculate_standings(
+        session,
+        league_id=league_id,
+        season_id=resolved_season_id,
+    )
+    response = SeasonStandingsRead(
+        league_id=league_id,
+        season_id=resolved_season_id,
+        items=[StandingsItem(**item) for item in raw_items],
+    )
+    cache.set(
+        league_id=league_id,
+        season_id=resolved_season_id,
+        payload=_serialize_response(response),
+    )
+    return response
+

--- a/api/app/schemas/standings.py
+++ b/api/app/schemas/standings.py
@@ -1,0 +1,19 @@
+﻿from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class StandingsItem(BaseModel):
+    driver_id: UUID
+    display_name: str
+    points: int
+    wins: int
+    best_finish: int | None
+
+
+class SeasonStandingsRead(BaseModel):
+    league_id: UUID
+    season_id: UUID | None
+    items: list[StandingsItem]

--- a/api/app/services/standings.py
+++ b/api/app/services/standings.py
@@ -1,0 +1,180 @@
+﻿from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+import redis
+from sqlalchemy import and_, case, func, select
+from sqlalchemy.orm import Session
+
+from app.db.models import Driver, Event, EventStatus, Result
+
+logger = logging.getLogger("app.standings")
+
+
+@dataclass
+class StandingsCacheConfig:
+    redis_url: str
+    ttl_seconds: int = 300
+
+
+class StandingsCache:
+    def __init__(self, config: StandingsCacheConfig) -> None:
+        self.config = config
+        self._redis_client: redis.Redis | None = None
+        self._memory_store: dict[str, tuple[str, float]] = {}
+        try:
+            self._redis_client = redis.Redis.from_url(config.redis_url, decode_responses=True)
+            self._redis_client.ping()
+        except Exception as exc:  # pragma: no cover - fallback path
+            logger.warning(
+                "Standings cache Redis connection failed: %s -- using in-memory cache", exc
+            )
+            self._redis_client = None
+
+    def _build_key(self, league_id: UUID, season_id: UUID | None) -> str:
+        season_part = str(season_id) if season_id is not None else "none"
+        return f"standings:{league_id}:{season_part}".lower()
+
+    def get(self, *, league_id: UUID, season_id: UUID | None) -> dict[str, Any] | None:
+        key = self._build_key(league_id, season_id)
+        raw_payload: str | None
+        if self._redis_client is not None:
+            try:
+                raw_payload = self._redis_client.get(key)
+            except redis.RedisError as exc:  # pragma: no cover - treat as cache miss
+                logger.warning("Redis error fetching standings cache: %s", exc)
+                raw_payload = None
+        else:
+            record = self._memory_store.get(key)
+            if record is None:
+                raw_payload = None
+            else:
+                cached_value, expires_at = record
+                if expires_at < time.time():
+                    self._memory_store.pop(key, None)
+                    raw_payload = None
+                else:
+                    raw_payload = cached_value
+        if raw_payload is None:
+            return None
+        try:
+            return json.loads(raw_payload)
+        except json.JSONDecodeError:
+            logger.warning("Invalid standings cache payload for %s", key)
+            self.invalidate(league_id=league_id, season_id=season_id)
+            return None
+
+    def set(self, *, league_id: UUID, season_id: UUID | None, payload: dict[str, Any]) -> None:
+        key = self._build_key(league_id, season_id)
+        raw_payload = json.dumps(payload)
+        if self._redis_client is not None:
+            try:
+                self._redis_client.setex(key, self.config.ttl_seconds, raw_payload)
+                return
+            except redis.RedisError as exc:  # pragma: no cover - fallback to memory
+                logger.warning("Redis error storing standings cache: %s", exc)
+        expires_at = time.time() + self.config.ttl_seconds
+        self._memory_store[key] = (raw_payload, expires_at)
+
+    def invalidate(self, *, league_id: UUID, season_id: UUID | None) -> None:
+        key = self._build_key(league_id, season_id)
+        if self._redis_client is not None:
+            try:
+                self._redis_client.delete(key)
+            except redis.RedisError as exc:  # pragma: no cover - log and continue
+                logger.warning("Redis error deleting standings cache key %s: %s", key, exc)
+        self._memory_store.pop(key, None)
+
+
+def _sort_key(item: dict[str, Any]) -> tuple[int, int, int, str]:
+    best_finish = item["best_finish"]
+    best_finish_rank = best_finish if best_finish is not None else 1_000_000
+    return (-item["points"], -item["wins"], best_finish_rank, item["display_name"].lower())
+
+
+def calculate_standings(
+    session: Session,
+    *,
+    league_id: UUID,
+    season_id: UUID | None,
+) -> list[dict[str, Any]]:
+    event_filters = [
+        Event.league_id == league_id,
+        Event.status == EventStatus.COMPLETED.value,
+    ]
+    if season_id is None:
+        event_filters.append(Event.season_id.is_(None))
+    else:
+        event_filters.append(Event.season_id == season_id)
+
+    event_join = and_(Event.id == Result.event_id, *event_filters)
+
+    points_expr = func.coalesce(
+        func.sum(
+            case((Event.id.isnot(None), Result.total_points), else_=0),
+        ),
+        0,
+    ).label("points")
+    wins_expr = func.coalesce(
+        func.sum(
+            case((and_(Event.id.isnot(None), Result.finish_position == 1), 1), else_=0),
+        ),
+        0,
+    ).label("wins")
+    best_finish_expr = func.min(
+        case((Event.id.isnot(None), Result.finish_position))
+    ).label("best_finish")
+
+    stmt = (
+        select(
+            Driver.id.label("driver_id"),
+            Driver.display_name.label("display_name"),
+            points_expr,
+            wins_expr,
+            best_finish_expr,
+        )
+        .select_from(Driver)
+        .join(Result, Result.driver_id == Driver.id, isouter=True)
+        .join(Event, event_join, isouter=True)
+        .where(Driver.league_id == league_id)
+        .group_by(Driver.id, Driver.display_name)
+    )
+
+    rows = session.execute(stmt).all()
+
+    standings: list[dict[str, Any]] = []
+    for row in rows:
+        points_value = int(row.points or 0)
+        wins_value = int(row.wins or 0)
+        best_finish_value = int(row.best_finish) if row.best_finish is not None else None
+        standings.append(
+            {
+                "driver_id": row.driver_id,
+                "display_name": row.display_name,
+                "points": points_value,
+                "wins": wins_value,
+                "best_finish": best_finish_value,
+            }
+        )
+
+    standings.sort(key=_sort_key)
+    return standings
+
+
+_cache_instance: StandingsCache | None = None
+
+
+def get_standings_cache(config: StandingsCacheConfig) -> StandingsCache:
+    global _cache_instance  # noqa: PLW0603 - cache singleton for reuse
+    if (
+        _cache_instance is None
+        or _cache_instance.config.redis_url != config.redis_url
+        or _cache_instance.config.ttl_seconds != config.ttl_seconds
+    ):
+        _cache_instance = StandingsCache(config)
+    return _cache_instance

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,25 @@
+﻿from __future__ import annotations
+
+import sys
+import types
+
+if "dramatiq" not in sys.modules:
+    class _ActorStub:
+        def __init__(self, fn):
+            self.fn = fn
+
+        def send(self, *args, **kwargs):  # pragma: no cover - stub implementation
+            return None
+
+        def __call__(self, *args, **kwargs):
+            return self.fn(*args, **kwargs)
+
+    def _actor(*_args, **_kwargs):
+        def decorator(fn):
+            return _ActorStub(fn)
+
+        return decorator
+
+    module = types.ModuleType("dramatiq")
+    module.actor = _actor
+    sys.modules["dramatiq"] = module

--- a/api/tests/test_standings.py
+++ b/api/tests/test_standings.py
@@ -1,0 +1,477 @@
+﻿from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from http import HTTPStatus
+from uuid import uuid4
+
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+if "dramatiq" not in sys.modules:
+    class _ActorStub:
+        def __init__(self, fn):
+            self.fn = fn
+
+        def send(self, *args, **kwargs):  # pragma: no cover - stub
+            return None
+
+        def __call__(self, *args, **kwargs):
+            return self.fn(*args, **kwargs)
+
+    def _actor(*args, **kwargs):
+        def decorator(fn):
+            return _ActorStub(fn)
+
+        return decorator
+
+    sys.modules["dramatiq"] = types.SimpleNamespace(actor=_actor)
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.settings import Settings, get_settings
+from app.db import Base
+from app.db.models import (
+    Driver,
+    Event,
+    EventStatus,
+    League,
+    LeagueRole,
+    Membership,
+    PointsRule,
+    PointsScheme,
+    Result,
+    ResultStatus,
+    Season,
+    User,
+)
+from app.db.session import get_session
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.routes.auth import provide_discord_client
+from app.services import standings as standings_service
+from worker.jobs import standings as standings_jobs
+
+SQLALCHEMY_DATABASE_URL = "sqlite+pysqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    future=True,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+)
+
+
+class StubDiscordClient:
+    def __init__(self) -> None:  # pragma: no cover
+        pass
+
+    async def exchange_code(self, *, code: str, code_verifier: str) -> dict[str, str]:
+        return {"access_token": "token"}
+
+    async def fetch_user(self, *, access_token: str) -> dict[str, str]:
+        return {
+            "id": "123",
+            "username": "Stub",
+            "avatar": None,
+            "email": None,
+        }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_database() -> None:
+    for table in Base.metadata.sorted_tables:
+        for column in table.c:
+            default = getattr(column, "server_default", None)
+            if default is not None and hasattr(default, "arg") and "gen_random_uuid" in str(default.arg):
+                column.server_default = None
+    Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    get_settings.cache_clear()
+    standings_service._cache_instance = None
+
+    test_settings = Settings(
+        APP_ENV="test",
+        APP_URL="http://localhost:5173",
+        API_URL="http://localhost:8000",
+        DISCORD_CLIENT_ID="client",
+        DISCORD_CLIENT_SECRET="secret",  # noqa: S106
+        DISCORD_REDIRECT_URI="http://localhost:8000/auth/discord/callback",
+        JWT_SECRET="test-secret",  # noqa: S106
+        JWT_ACCESS_TTL_MIN=15,
+        JWT_REFRESH_TTL_DAYS=14,
+        CORS_ORIGINS="http://localhost:5173",
+        REDIS_URL="redis://localhost:6379/0",
+    )
+
+    app.dependency_overrides[get_settings] = lambda: test_settings
+
+    def get_test_session() -> Generator[Session, None, None]:
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_session] = get_test_session
+    app.dependency_overrides[provide_discord_client] = lambda: StubDiscordClient()
+    monkeypatch.setattr(standings_jobs.recompute_standings, "send", lambda *args, **kwargs: None)
+
+    yield
+
+    app.dependency_overrides.clear()
+    standings_service._cache_instance = None
+
+
+@contextmanager
+def override_user(user: User) -> Generator[None, None, None]:
+    app.dependency_overrides[get_current_user] = lambda: user
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def database_session() -> Generator[Session, None, None]:
+    session = TestingSessionLocal()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def stub_user(session: Session, discord_id: str) -> User:
+    user = User(discord_id=discord_id, discord_username=discord_id)
+    session.add(user)
+    session.commit()
+    return user
+
+
+def create_league_with_owner(session: Session, owner: User) -> tuple[League, Season]:
+    league = League(
+        name="Test League",
+        slug=f"league-{uuid4().hex[:8]}",
+        owner_id=owner.id,
+    )
+    season = Season(league=league, name="Season", is_active=True)
+    membership = Membership(league=league, user_id=owner.id, role=LeagueRole.OWNER)
+    session.add_all([league, season, membership])
+    session.commit()
+    session.refresh(league)
+    session.refresh(season)
+    return league, season
+
+
+def create_driver(session: Session, league: League, *, display_name: str) -> Driver:
+    driver = Driver(league_id=league.id, display_name=display_name)
+    session.add(driver)
+    session.commit()
+    session.refresh(driver)
+    return driver
+
+
+def create_event(session: Session, league: League, season: Season, *, name: str) -> Event:
+    event = Event(
+        league_id=league.id,
+        season_id=season.id,
+        name=name,
+        track="Test Track",
+        start_time=datetime.now(UTC),
+        status=EventStatus.SCHEDULED.value,
+    )
+    session.add(event)
+    session.commit()
+    session.refresh(event)
+    return event
+
+
+def record_result(
+    session: Session,
+    *,
+    event: Event,
+    driver: Driver,
+    finish_position: int,
+    total_points: int,
+    bonus_points: int = 0,
+    penalty_points: int = 0,
+) -> Result:
+    result = Result(
+        event_id=event.id,
+        driver_id=driver.id,
+        finish_position=finish_position,
+        started_position=finish_position,
+        status=ResultStatus.FINISHED.value,
+        bonus_points=bonus_points,
+        penalty_points=penalty_points,
+        total_points=total_points,
+    )
+    session.add(result)
+    session.commit()
+    session.refresh(result)
+    return result
+
+
+def seed_points_scheme(session: Session, league: League, season: Season) -> PointsScheme:
+    scheme = PointsScheme(
+        league_id=league.id,
+        season_id=season.id,
+        name="Default",
+        is_default=True,
+    )
+    rules = [
+        PointsRule(position=1, points=25),
+        PointsRule(position=2, points=18),
+        PointsRule(position=3, points=15),
+        PointsRule(position=4, points=12),
+    ]
+    scheme.rules = rules
+    session.add(scheme)
+    session.commit()
+    session.refresh(scheme)
+    return scheme
+
+
+class TestStandingsRoutes:
+    def test_standings_orders_by_points_wins_best_finish(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        league, season = create_league_with_owner(database_session, owner)
+        driver_a = create_driver(database_session, league, display_name="Driver A")
+        driver_b = create_driver(database_session, league, display_name="Driver B")
+        driver_c = create_driver(database_session, league, display_name="Driver C")
+
+        event_one = create_event(database_session, league, season, name="Race 1")
+        event_two = create_event(database_session, league, season, name="Race 2")
+        event_one.status = EventStatus.COMPLETED.value
+        event_two.status = EventStatus.COMPLETED.value
+        database_session.commit()
+
+        record_result(
+            database_session,
+            event=event_one,
+            driver=driver_a,
+            finish_position=1,
+            total_points=25,
+        )
+        record_result(
+            database_session,
+            event=event_one,
+            driver=driver_b,
+            finish_position=2,
+            total_points=15,
+        )
+        record_result(
+            database_session,
+            event=event_two,
+            driver=driver_a,
+            finish_position=3,
+            total_points=10,
+        )
+        record_result(
+            database_session,
+            event=event_two,
+            driver=driver_b,
+            finish_position=2,
+            total_points=20,
+        )
+        database_session.commit()
+
+        with override_user(owner):
+            response = client.get(
+                f"/leagues/{league.id}/standings",
+                params={"seasonId": str(season.id)},
+            )
+        assert response.status_code == HTTPStatus.OK, response.text
+        data = response.json()
+        assert data["season_id"] == str(season.id)
+        items = data["items"]
+        assert [item["driver_id"] for item in items] == [
+            str(driver_a.id),
+            str(driver_b.id),
+            str(driver_c.id),
+        ]
+        assert items[0]["points"] == 35
+        assert items[0]["wins"] == 1
+        assert items[0]["best_finish"] == 1
+        assert items[1]["points"] == 35
+        assert items[1]["wins"] == 0
+        assert items[1]["best_finish"] == 2
+        assert items[2]["points"] == 0
+        assert items[2]["wins"] == 0
+        assert items[2]["best_finish"] is None
+
+        with override_user(owner):
+            default_response = client.get(f"/leagues/{league.id}/standings")
+        assert default_response.status_code == HTTPStatus.OK
+        assert default_response.json()["items"] == items
+
+    def test_standings_requires_membership(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        outsider = stub_user(database_session, "outsider")
+        league, season = create_league_with_owner(database_session, owner)
+
+        event = create_event(database_session, league, season, name="Race 1")
+        event.status = EventStatus.COMPLETED.value
+        database_session.commit()
+
+        record_result(
+            database_session,
+            event=event,
+            driver=create_driver(database_session, league, display_name="Driver"),
+            finish_position=1,
+            total_points=25,
+        )
+
+        with override_user(outsider):
+            response = client.get(
+                f"/leagues/{league.id}/standings",
+                params={"seasonId": str(season.id)},
+            )
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        payload = response.json()
+        assert payload["error"]["code"] == "NOT_A_MEMBER"
+
+    def test_standings_cache_invalidation_on_results_update(
+        self,
+        client: TestClient,
+        database_session: Session,
+    ) -> None:
+        owner = stub_user(database_session, "owner")
+        steward = owner
+        league, season = create_league_with_owner(database_session, owner)
+        driver_a = create_driver(database_session, league, display_name="Driver A")
+        driver_b = create_driver(database_session, league, display_name="Driver B")
+
+        event = create_event(database_session, league, season, name="Race 1")
+        seed_points_scheme(database_session, league, season)
+
+        initial_payload = {
+            "entries": [
+                {
+                    "driver_id": str(driver_a.id),
+                    "finish_position": 1,
+                    "started_position": 1,
+                    "status": "FINISHED",
+                    "bonus_points": 0,
+                    "penalty_points": 0,
+                },
+                {
+                    "driver_id": str(driver_b.id),
+                    "finish_position": 2,
+                    "started_position": 2,
+                    "status": "FINISHED",
+                    "bonus_points": 0,
+                    "penalty_points": 0,
+                },
+            ]
+        }
+
+        with override_user(steward):
+            post_response = client.post(
+                f"/events/{event.id}/results",
+                json=initial_payload,
+                headers={"Idempotency-Key": uuid4().hex},
+            )
+        assert post_response.status_code == HTTPStatus.CREATED, post_response.text
+
+        with override_user(owner):
+            first_standings = client.get(
+                f"/leagues/{league.id}/standings",
+                params={"seasonId": str(season.id)},
+            )
+        assert first_standings.status_code == HTTPStatus.OK
+        first_payload = first_standings.json()
+
+        result_b = database_session.execute(
+            select(Result).where(Result.event_id == event.id, Result.driver_id == driver_b.id)
+        ).scalar_one()
+        result_b.total_points = 99
+        database_session.commit()
+
+        with override_user(owner):
+            cached_response = client.get(
+                f"/leagues/{league.id}/standings",
+                params={"seasonId": str(season.id)},
+            )
+        assert cached_response.status_code == HTTPStatus.OK
+        assert cached_response.json() == first_payload
+
+        update_payload = {
+            "entries": [
+                {
+                    "driver_id": str(driver_a.id),
+                    "finish_position": 2,
+                    "started_position": 2,
+                    "status": "FINISHED",
+                    "bonus_points": 0,
+                    "penalty_points": 8,
+                },
+                {
+                    "driver_id": str(driver_b.id),
+                    "finish_position": 1,
+                    "started_position": 1,
+                    "status": "FINISHED",
+                    "bonus_points": 5,
+                    "penalty_points": 0,
+                },
+            ]
+        }
+
+        with override_user(steward):
+            update_response = client.post(
+                f"/events/{event.id}/results",
+                json=update_payload,
+                headers={"Idempotency-Key": uuid4().hex},
+            )
+        assert update_response.status_code == HTTPStatus.CREATED, update_response.text
+
+        with override_user(owner):
+            refreshed = client.get(
+                f"/leagues/{league.id}/standings",
+                params={"seasonId": str(season.id)},
+            )
+        assert refreshed.status_code == HTTPStatus.OK
+        refreshed_payload = refreshed.json()
+        assert refreshed_payload != first_payload
+        refreshed_items = refreshed_payload["items"]
+        assert refreshed_items[0]["driver_id"] == str(driver_b.id)
+        assert refreshed_items[0]["points"] == 30
+        assert refreshed_items[1]["driver_id"] == str(driver_a.id)
+        assert refreshed_items[1]["points"] == 10
+
+
+

--- a/docs/AppPBIs.md
+++ b/docs/AppPBIs.md
@@ -110,7 +110,7 @@ Acceptance Criteria:
 Dependencies: PBI-009, PBI-008, PBI-010
 Branch: pbi/011-results-processing
 
-## PBI-012 - Standings Service and Cache
+## PBI-012 - Standings Service and Cache (complete)
 Summary: Provide season standings aggregation with caching and tie breakers.
 Scope: Backend
 Acceptance Criteria:


### PR DESCRIPTION
Merge summary:

Add cached standings service and expose /standings API.
Invalidate cached standings when results change and register the router.
Cover standings ordering, RBAC, and cache flow with new tests and mark PBI-012 complete.