### PR TITLE
feat(bot): deliver Discord bot service with announcement queue (PBI-014)

### DIFF
--- a/api/tests/test_discord_jobs.py
+++ b/api/tests/test_discord_jobs.py
@@ -1,0 +1,231 @@
+﻿from __future__ import annotations
+
+import importlib
+from collections.abc import Generator
+from uuid import uuid4
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db import Base
+from app.db.models import AuditLog, DiscordIntegration, Driver, Event, EventStatus, League, Result, ResultStatus, Season
+import app.db.session as db_session
+
+# Configure shared in-memory database for worker job tests.
+engine = create_engine(
+    "sqlite+pysqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+    future=True,
+)
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+for table in Base.metadata.sorted_tables:
+    for column in table.c:
+        default = getattr(column, "server_default", None)
+        if default is not None and hasattr(default, "arg") and "gen_random_uuid" in str(default.arg):
+            column.server_default = None
+
+Base.metadata.create_all(bind=engine)
+
+
+def reset_database() -> None:
+    with engine.begin() as connection:
+        for table in reversed(Base.metadata.sorted_tables):
+            connection.execute(table.delete())
+
+
+def configure_session() -> None:
+    db_session._engine = engine  # type: ignore[attr-defined]
+    db_session.SessionLocal = TestingSessionLocal  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    configure_session()
+    import worker.jobs.discord as discord_jobs_module
+    import worker.services.discord as discord_service_module
+
+    importlib.reload(discord_service_module)
+    importlib.reload(discord_jobs_module)
+
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+
+    yield
+
+    reset_database()
+
+
+class StubNotifier:
+    def __init__(self, *, should_raise: Exception | None = None) -> None:
+        self.messages: list[tuple[str, object]] = []
+        self.should_raise = should_raise
+
+    def send(self, channel_id: str, message: object) -> None:
+        if self.should_raise:
+            raise self.should_raise
+        self.messages.append((channel_id, message))
+
+
+def create_league(session: Session, *, plan: str = "PRO") -> League:
+    league = League(name="League", slug=f"league-{uuid4().hex[:8]}", plan=plan)
+    session.add(league)
+    session.commit()
+    session.refresh(league)
+    return league
+
+
+def create_event_with_results(session: Session, league: League) -> Event:
+    season = Season(league_id=league.id, name="Season", is_active=True)
+    event = Event(
+        league_id=league.id,
+        season=season,
+        name="Race 1",
+        track="Monza",
+        start_time=datetime.now(timezone.utc),
+        status=EventStatus.COMPLETED.value,
+    )
+    driver = Driver(league_id=league.id, display_name="Driver A")
+    session.add_all([season, event, driver])
+    session.commit()
+    session.refresh(event)
+    result = Result(
+        event_id=event.id,
+        driver_id=driver.id,
+        finish_position=1,
+        started_position=1,
+        status=EventStatus.COMPLETED.value,
+        bonus_points=0,
+        penalty_points=0,
+        total_points=25,
+    )
+    session.add(result)
+    session.commit()
+    return event
+
+
+def test_send_test_message_posts(monkeypatch: pytest.MonkeyPatch) -> None:
+    import worker.jobs.discord as discord_jobs_module
+
+    notifier = StubNotifier()
+    monkeypatch.setattr(discord_jobs_module, "_get_notifier", lambda: notifier)
+
+    session = TestingSessionLocal()
+    league = create_league(session)
+    integration = DiscordIntegration(
+        league_id=league.id,
+        guild_id="guild",
+        channel_id="channel",
+        installed_by_user=None,
+        is_active=True,
+    )
+    session.add(integration)
+    session.commit()
+
+    discord_jobs_module.send_test_message.fn(str(league.id), "guild", "channel")
+
+    assert notifier.messages and notifier.messages[0][0] == "channel"
+
+
+def test_send_test_message_marks_inactive_on_permission_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import worker.jobs.discord as discord_jobs_module
+    from worker.services.discord import DiscordPermissionError
+
+    notifier = StubNotifier(should_raise=DiscordPermissionError("forbidden"))
+    monkeypatch.setattr(discord_jobs_module, "_get_notifier", lambda: notifier)
+
+    session = TestingSessionLocal()
+    league = create_league(session)
+    integration = DiscordIntegration(
+        league_id=league.id,
+        guild_id="guild",
+        channel_id="channel",
+        installed_by_user=None,
+        is_active=True,
+    )
+    session.add(integration)
+    session.commit()
+
+    with pytest.raises(DiscordPermissionError):
+        discord_jobs_module.send_test_message.fn(str(league.id), "guild", "channel")
+
+    session.close()
+    check_session = TestingSessionLocal()
+    refreshed = check_session.execute(
+        select(DiscordIntegration).where(DiscordIntegration.id == integration.id)
+    ).scalar_one()
+    assert refreshed.is_active is False
+
+    audit = check_session.execute(select(AuditLog).where(AuditLog.league_id == league.id)).scalar_one()
+    assert audit.action == "discord_deactivated"
+    check_session.close()
+
+
+def test_announce_results_sends_embed(monkeypatch: pytest.MonkeyPatch) -> None:
+    import worker.jobs.discord as discord_jobs_module
+
+    notifier = StubNotifier()
+    monkeypatch.setattr(discord_jobs_module, "_get_notifier", lambda: notifier)
+
+    session = TestingSessionLocal()
+    league = create_league(session)
+    integration = DiscordIntegration(
+        league_id=league.id,
+        guild_id="guild",
+        channel_id="channel",
+        installed_by_user=None,
+        is_active=True,
+    )
+    session.add(integration)
+    session.commit()
+
+    event = create_event_with_results(session, league)
+
+    discord_jobs_module.announce_results.fn(str(league.id), str(event.id))
+
+    assert notifier.messages
+    channel, message = notifier.messages[0]
+    assert channel == "channel"
+    assert message.embeds and message.embeds[0]["title"].endswith("Results")
+
+
+def test_announce_results_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    import worker.jobs.discord as discord_jobs_module
+    from worker.services.discord import DiscordRateLimitError
+
+    notifier = StubNotifier(should_raise=DiscordRateLimitError("retry"))
+    monkeypatch.setattr(discord_jobs_module, "_get_notifier", lambda: notifier)
+
+    session = TestingSessionLocal()
+    league = create_league(session)
+    integration = DiscordIntegration(
+        league_id=league.id,
+        guild_id="guild",
+        channel_id="channel",
+        installed_by_user=None,
+        is_active=True,
+    )
+    session.add(integration)
+    session.commit()
+
+    event = create_event_with_results(session, league)
+
+    with pytest.raises(DiscordRateLimitError):
+        discord_jobs_module.announce_results.fn(str(league.id), str(event.id))
+
+    refreshed = session.execute(select(DiscordIntegration).where(DiscordIntegration.id == integration.id)).scalar_one()
+    assert refreshed.is_active is True
+
+
+
+
+
+
+
+
+
+
+

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,19 @@
+﻿from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+@dataclass(frozen=True)
+class BotConfig:
+    token: str
+    app_url: str
+    link_path: str = "/settings/discord"
+
+
+def load_config() -> BotConfig:
+    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    app_url = os.getenv("APP_URL", "http://localhost:5173")
+    link_path = os.getenv("DISCORD_LINK_PATH", "/settings/discord")
+
+    return BotConfig(token=token, app_url=app_url.rstrip("/"), link_path=link_path)

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,20 +1,106 @@
-"""Placeholder Discord bot entrypoint for local development."""
+﻿"""GridBoss Discord bot entrypoint."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
-import time
+import sys
+from typing import Optional
+
+try:
+    import discord
+    from discord import app_commands
+except ImportError:  # pragma: no cover - library optional in test env
+    discord = None  # type: ignore
+    app_commands = None  # type: ignore
+
+from bot.config import BotConfig, load_config
+from bot.service import CommandResponse, GridBossBot, InteractionContext
 
 logging.basicConfig(level=logging.INFO, format="[bot] %(message)s")
+logger = logging.getLogger("gridboss.bot")
+
+
+def _interaction_context(interaction: "discord.Interaction", *, is_admin: bool) -> InteractionContext:
+    guild_id = str(interaction.guild_id or getattr(interaction.guild, "id", "unknown"))
+    channel_id = str(interaction.channel_id or getattr(interaction.channel, "id", "unknown"))
+    user_id = str(interaction.user.id if interaction.user else "unknown")
+    return InteractionContext(guild_id=guild_id, channel_id=channel_id, user_id=user_id, is_admin=is_admin)
+
+
+def _is_admin(interaction: "discord.Interaction") -> bool:
+    perms = getattr(interaction.user, "guild_permissions", None)
+    if perms is None:
+        return False
+    return bool(getattr(perms, "administrator", False) or getattr(perms, "manage_guild", False))
+
+
+async def _handle_interaction(
+    bot_app: GridBossBot,
+    interaction: "discord.Interaction",
+    command: str,
+) -> None:
+    is_admin = _is_admin(interaction)
+    context = _interaction_context(interaction, is_admin=is_admin)
+    response: CommandResponse = bot_app.process_command(command, context)
+    await interaction.response.send_message(response.content, ephemeral=response.ephemeral)
+
+
+def _run_discord_bot(config: BotConfig, bot_app: GridBossBot) -> None:
+    if discord is None or app_commands is None:
+        logger.warning("discord.py is not installed. Falling back to no-op loop.")
+        _run_noop_loop()
+        return
+    if not config.token:
+        logger.warning("DISCORD_BOT_TOKEN is not configured.")
+        _run_noop_loop()
+        return
+
+    class GridBossDiscordClient(discord.Client):  # type: ignore[misc]
+        def __init__(self) -> None:
+            intents = discord.Intents.none()
+            super().__init__(intents=intents)
+            self.tree = app_commands.CommandTree(self)
+
+        async def setup_hook(self) -> None:  # pragma: no cover - requires discord runtime
+            gridboss_group = app_commands.Group(name="gridboss", description="GridBoss utilities")
+
+            @gridboss_group.command(name="link", description="Generate a link to connect this guild to GridBoss")
+            async def link_command(interaction: discord.Interaction) -> None:  # type: ignore[valid-type]
+                await _handle_interaction(bot_app, interaction, "link")
+
+            @gridboss_group.command(name="test", description="Send a test announcement to the configured channel")
+            async def test_command(interaction: discord.Interaction) -> None:  # type: ignore[valid-type]
+                await _handle_interaction(bot_app, interaction, "test")
+
+            self.tree.add_command(gridboss_group)
+            await self.tree.sync()
+            logger.info("Slash commands synced with Discord")
+
+        async def on_ready(self) -> None:  # pragma: no cover - requires discord runtime
+            logger.info("GridBoss bot connected as %s", self.user)
+
+    client = GridBossDiscordClient()
+    client.run(config.token)
+
+
+def _run_noop_loop() -> None:
+    logger.info("GridBoss bot idle. Install discord.py and configure DISCORD_BOT_TOKEN to enable full functionality.")
+    try:
+        asyncio.run(_idle())
+    except KeyboardInterrupt:
+        logger.info("Discord bot stopping.")
+
+
+async def _idle() -> None:
+    while True:  # pragma: no cover - manual stop required
+        await asyncio.sleep(60)
 
 
 def main() -> None:
-    logging.info("Discord bot placeholder running. Waiting for future integration...")
-    try:
-        while True:
-            time.sleep(60)
-    except KeyboardInterrupt:
-        logging.info("Discord bot stopping.")
+    config = load_config()
+    bot_app = GridBossBot(config)
+    _run_discord_bot(config, bot_app)
 
 
 if __name__ == "__main__":

--- a/bot/service.py
+++ b/bot/service.py
@@ -1,0 +1,108 @@
+﻿from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models import DiscordIntegration
+from app.db.session import get_sessionmaker
+from worker.jobs import discord as discord_jobs
+
+from .config import BotConfig
+
+
+@dataclass
+class InteractionContext:
+    guild_id: str
+    channel_id: str
+    user_id: str
+    is_admin: bool
+
+
+@dataclass
+class CommandResponse:
+    content: str
+    ephemeral: bool = True
+
+
+class GridBossBot:
+    """Command-first Discord bot orchestration for GridBoss."""
+
+    def __init__(self, config: BotConfig) -> None:
+        self.config = config
+        self._session_factory = get_sessionmaker()
+        self._commands: Dict[str, Callable[[InteractionContext], CommandResponse]] = {
+            "link": self._handle_link,
+            "test": self._handle_test,
+        }
+
+    @property
+    def commands(self) -> dict[str, str]:
+        return {
+            "link": "Generate a secure link to connect this Discord server to GridBoss.",
+            "test": "Verify the bot can post to the configured channel.",
+        }
+
+    def process_command(self, name: str, context: InteractionContext) -> CommandResponse:
+        handler = self._commands.get(name)
+        if handler is None:
+            return CommandResponse(content="Unknown command.")
+        return handler(context)
+
+    def _handle_link(self, context: InteractionContext) -> CommandResponse:
+        if not context.is_admin:
+            return CommandResponse(
+                content="You need the Manage Server permission to link this Discord server to GridBoss.",
+                ephemeral=True,
+            )
+
+        link_url = f"{self.config.app_url}{self.config.link_path}?guildId={context.guild_id}"
+        message = (
+            "🔗 Use the secure link below to connect this server to GridBoss."
+            " Only Owners/Admins in your league can complete the flow.\n\n"
+            f"<{link_url}>"
+        )
+        return CommandResponse(content=message, ephemeral=True)
+
+    def _handle_test(self, context: InteractionContext) -> CommandResponse:
+        if not context.is_admin:
+            return CommandResponse(
+                content="You need the Manage Server permission to run a test.",
+                ephemeral=True,
+            )
+
+        session: Session = self._session_factory()
+        try:
+            integration = (
+                session.execute(
+                    select(DiscordIntegration).where(DiscordIntegration.guild_id == context.guild_id)
+                )
+                .scalars()
+                .first()
+            )
+            if integration is None:
+                return CommandResponse(
+                    content="This server has not been linked to a GridBoss league yet.", ephemeral=True
+                )
+            if not integration.is_active:
+                return CommandResponse(
+                    content="The Discord integration is currently inactive. An admin should relink it via GridBoss.",
+                    ephemeral=True,
+                )
+            if not integration.channel_id:
+                return CommandResponse(
+                    content="No announcement channel is configured. Update the integration in GridBoss first.",
+                    ephemeral=True,
+                )
+
+            discord_jobs.send_test_message.send(
+                str(integration.league_id), integration.guild_id, integration.channel_id
+            )
+            return CommandResponse(
+                content="✅ Test message queued! Check your announcement channel for a confirmation message.",
+                ephemeral=True,
+            )
+        finally:
+            session.close()

--- a/bot/tests/test_service.py
+++ b/bot/tests/test_service.py
@@ -1,0 +1,165 @@
+﻿from __future__ import annotations
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import importlib
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[2]
+API_ROOT = ROOT / "api"
+for candidate in (ROOT, API_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.append(str(candidate))
+
+if "dramatiq" not in sys.modules:
+    class _ActorStub:
+        def __init__(self, fn) -> None:
+            self.fn = fn
+
+        def send(self, *args, **kwargs):  # pragma: no cover - stub
+            return None
+
+        def __call__(self, *args, **kwargs):
+            return self.fn(*args, **kwargs)
+
+    def _actor(*args, **kwargs):
+        def decorator(fn):
+            return _ActorStub(fn)
+
+        return decorator
+
+    sys.modules["dramatiq"] = types.SimpleNamespace(actor=_actor)
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db import Base
+from app.db.models import DiscordIntegration, League
+import app.db.session as db_session
+from bot.config import BotConfig
+from bot.service import GridBossBot, InteractionContext
+
+
+SQLALCHEMY_DATABASE_URL = "sqlite+pysqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+    future=True,
+)
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+for table in Base.metadata.sorted_tables:
+    for column in table.c:
+        default = getattr(column, "server_default", None)
+        if default is not None and hasattr(default, "arg") and "gen_random_uuid" in str(default.arg):
+            column.server_default = None
+
+Base.metadata.create_all(bind=engine)
+
+
+def reset_database() -> None:
+    with engine.begin() as connection:
+        for table in reversed(Base.metadata.sorted_tables):
+            connection.execute(table.delete())
+
+
+def configure_session() -> None:
+    db_session._engine = engine  # type: ignore[attr-defined]
+    db_session.SessionLocal = TestingSessionLocal  # type: ignore[attr-defined]
+
+
+def create_league(session: Session, *, plan: str = "PRO") -> League:
+    league = League(name="League", slug=f"league-{uuid4().hex[:8]}", plan=plan)
+    session.add(league)
+    session.commit()
+    session.refresh(league)
+    return league
+
+
+class DummyActor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def send(self, league_id: str, guild_id: str, channel_id: str) -> None:
+        self.calls.append((league_id, guild_id, channel_id))
+
+
+def setup_module() -> None:  # noqa: D401
+    """Configure shared session for the module."""
+    configure_session()
+
+
+class TestGridBossBot:
+    def setup_method(self) -> None:
+        reset_database()
+        import worker.jobs.discord as discord_jobs_module
+        import bot.service as bot_service
+
+        importlib.reload(discord_jobs_module)
+        bot_service.discord_jobs = discord_jobs_module  # type: ignore[assignment]
+
+        self.spied_actor = DummyActor()
+        bot_service.discord_jobs.send_test_message = self.spied_actor  # type: ignore[assignment]
+
+    def test_link_requires_admin(self) -> None:
+        bot = GridBossBot(BotConfig(token="", app_url="http://local"))
+        context = InteractionContext(guild_id="1", channel_id="10", user_id="100", is_admin=False)
+
+        response = bot.process_command("link", context)
+
+        assert "Manage Server" in response.content
+        assert response.ephemeral is True
+
+    def test_link_returns_signed_url(self) -> None:
+        bot = GridBossBot(BotConfig(token="", app_url="https://gridboss.app"))
+        context = InteractionContext(guild_id="987", channel_id="10", user_id="42", is_admin=True)
+
+        response = bot.process_command("link", context)
+
+        assert "https://gridboss.app/settings/discord?guildId=987" in response.content
+        assert response.ephemeral is True
+
+    def test_test_command_enqueues_job(self) -> None:
+        bot = GridBossBot(BotConfig(token="", app_url="http://local"))
+        session = TestingSessionLocal()
+        league = create_league(session)
+        integration = DiscordIntegration(
+            league_id=league.id,
+            guild_id="guild",
+            channel_id="channel",
+            installed_by_user=None,
+            is_active=True,
+        )
+        session.add(integration)
+        session.commit()
+
+        context = InteractionContext(guild_id="guild", channel_id="channel", user_id="user", is_admin=True)
+        response = bot.process_command("test", context)
+
+        assert "Test message queued" in response.content
+        assert self.spied_actor.calls == [(str(league.id), "guild", "channel")]
+
+    def test_test_command_checks_integration_state(self) -> None:
+        bot = GridBossBot(BotConfig(token="", app_url="http://local"))
+        session = TestingSessionLocal()
+        league = create_league(session)
+        integration = DiscordIntegration(
+            league_id=league.id,
+            guild_id="guild",
+            channel_id="channel",
+            installed_by_user=None,
+            is_active=False,
+        )
+        session.add(integration)
+        session.commit()
+
+        context = InteractionContext(guild_id="guild", channel_id="channel", user_id="user", is_admin=True)
+        response = bot.process_command("test", context)
+
+        assert "inactive" in response.content.lower()
+        assert not self.spied_actor.calls

--- a/docs/AppPBIs.md
+++ b/docs/AppPBIs.md
@@ -130,7 +130,7 @@ Acceptance Criteria:
 Dependencies: PBI-006, PBI-010, PBI-017
 Branch: pbi/013-discord-integration-api
 
-## PBI-014 - Discord Bot Service
+## PBI-014 - Discord Bot Service (complete)
 Summary: Build the discord.py bot that handles slash commands and queue driven announcements.
 Scope: Backend, Ops
 Acceptance Criteria:

--- a/worker/jobs/__init__.py
+++ b/worker/jobs/__init__.py
@@ -1,7 +1,12 @@
 ﻿from __future__ import annotations
 
-from .discord import send_test_message
+from .discord import announce_results, send_test_message
 from .heartbeat import heartbeat
-from .standings import announce_results, recompute_standings
+from .standings import recompute_standings
 
-__all__ = ["heartbeat", "announce_results", "recompute_standings", "send_test_message"]
+__all__ = [
+    "heartbeat",
+    "recompute_standings",
+    "announce_results",
+    "send_test_message",
+]

--- a/worker/jobs/discord.py
+++ b/worker/jobs/discord.py
@@ -1,17 +1,212 @@
 ﻿from __future__ import annotations
 
 import logging
+import uuid
 
 import dramatiq
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+
+from app.db.models import AuditLog, DiscordIntegration, Event, League, Result
+from app.db.session import get_sessionmaker
+from worker.services.discord import (
+    DiscordConfigurationError,
+    DiscordMessage,
+    DiscordNotifier,
+    DiscordPermissionError,
+    DiscordRateLimitError,
+    build_results_embed,
+    create_notifier_from_env,
+)
 
 logger = logging.getLogger("worker.jobs.discord")
 
+SessionLocal = get_sessionmaker()
 
-@dramatiq.actor(max_retries=3)
-def send_test_message(league_id: str, guild_id: str, channel_id: str) -> None:
-    logger.info(
-        "Discord test message queued (league=%s, guild=%s, channel=%s)",
-        league_id,
-        guild_id,
-        channel_id,
+
+def _session():
+    return SessionLocal()
+
+
+def _get_notifier() -> DiscordNotifier | None:
+    try:
+        return create_notifier_from_env()
+    except DiscordConfigurationError as exc:
+        logger.error("Discord notifier configuration error: %s", exc)
+        return None
+
+
+def _record_failure(session, integration: DiscordIntegration, *, reason: str) -> None:
+    before_state = {
+        "is_active": integration.is_active,
+        "channel_id": integration.channel_id,
+        "guild_id": integration.guild_id,
+    }
+    integration.is_active = False
+    log_entry = AuditLog(
+        actor_id=None,
+        league_id=integration.league_id,
+        entity="discord_integration",
+        entity_id=str(integration.id),
+        action="discord_deactivated",
+        before_state=before_state,
+        after_state={**before_state, "is_active": False, "reason": reason},
     )
+    session.add(log_entry)
+
+
+def _build_results_payload(session, event: Event) -> dict[str, str | list[dict[str, object]]]:
+    league = session.get(League, event.league_id)
+    season_name = None
+    if event.season_id:
+        season = event.season
+        if season is not None:
+            season_name = season.name
+    results = (
+        session.execute(
+            select(Result)
+            .options(joinedload(Result.driver))
+            .where(Result.event_id == event.id)
+            .order_by(Result.finish_position)
+        )
+        .scalars()
+        .all()
+    )
+    entries = [
+        {
+            "driver": result.driver.display_name if result.driver else "Unknown",
+            "points": result.total_points,
+            "status": result.status,
+        }
+        for result in results
+    ]
+    embed = build_results_embed(
+        event_name=event.name,
+        league_name=league.name if league else "League",
+        season_name=season_name,
+        results=entries,
+    )
+    return {"embeds": [embed]}
+
+
+@dramatiq.actor(max_retries=5)
+def send_test_message(league_id: str, guild_id: str, channel_id: str) -> None:
+    notifier = _get_notifier()
+    if notifier is None:
+        logger.warning("Skipping Discord test message because notifier is not configured")
+        return
+
+    session = _session()
+    try:
+        integration = (
+            session.execute(
+                select(DiscordIntegration).where(DiscordIntegration.league_id == uuid.UUID(league_id))
+            )
+            .scalars()
+            .first()
+        )
+        if integration is None:
+            logger.info("No Discord integration for league %s", league_id)
+            return
+        if not integration.is_active:
+            logger.info("Discord integration inactive for league %s", league_id)
+            return
+
+        message = DiscordMessage(content="Test message queued! GridBoss bot is connected and ready.")
+        notifier.send(channel_id, message)
+        logger.info("Discord test message dispatched (league=%s, channel=%s)", league_id, channel_id)
+    except DiscordRateLimitError:
+        session.rollback()
+        raise
+    except DiscordPermissionError as exc:
+        session.rollback()
+        logger.error("Discord test message failed: %s", exc, extra={"league": league_id, "channel": channel_id})
+        session.begin()
+        refreshed = session.execute(
+            select(DiscordIntegration).where(DiscordIntegration.league_id == uuid.UUID(league_id))
+        ).scalars().first()
+        if refreshed is not None:
+            _record_failure(session, refreshed, reason="permission_error")
+        session.commit()
+        raise
+    except Exception:  # pragma: no cover - unexpected errors
+        session.rollback()
+        raise
+    else:
+        session.commit()
+    finally:
+        session.close()
+
+
+@dramatiq.actor(max_retries=5)
+def announce_results(league_id: str, event_id: str) -> None:
+    notifier = _get_notifier()
+    if notifier is None:
+        logger.warning("Skipping results announcement because notifier is not configured")
+        return
+
+    session = _session()
+    try:
+        integration = (
+            session.execute(
+                select(DiscordIntegration)
+                .options(joinedload(DiscordIntegration.league))
+                .where(DiscordIntegration.league_id == uuid.UUID(league_id))
+            )
+            .scalars()
+            .first()
+        )
+        if integration is None or not integration.channel_id:
+            logger.info("No Discord channel configured for league %s", league_id)
+            return
+        if not integration.is_active:
+            logger.info("Discord integration inactive for league %s", league_id)
+            return
+
+        event = (
+            session.execute(
+                select(Event)
+                .options(joinedload(Event.season))
+                .where(Event.id == uuid.UUID(event_id))
+            )
+            .scalars()
+            .first()
+        )
+        if event is None:
+            logger.warning("Event %s not found for Discord announcement", event_id)
+            return
+
+        payload = _build_results_payload(session, event)
+        message = DiscordMessage(content=None, embeds=payload["embeds"])
+        notifier.send(integration.channel_id, message)
+        logger.info(
+            "Discord results announcement delivered (league=%s, event=%s)", league_id, event_id
+        )
+    except DiscordRateLimitError:
+        session.rollback()
+        raise
+    except DiscordPermissionError as exc:
+        session.rollback()
+        logger.error(
+            "Discord results announcement failed: %s",
+            exc,
+            extra={"league": league_id, "event": event_id},
+        )
+        session.begin()
+        refreshed = session.execute(
+            select(DiscordIntegration).where(DiscordIntegration.league_id == uuid.UUID(league_id))
+        ).scalars().first()
+        if refreshed is not None:
+            _record_failure(session, refreshed, reason="permission_error")
+        session.commit()
+        raise
+    except Exception:  # pragma: no cover - unexpected
+        session.rollback()
+        raise
+    else:
+        session.commit()
+    finally:
+        session.close()
+
+
+__all__ = ["send_test_message", "announce_results"]

--- a/worker/jobs/standings.py
+++ b/worker/jobs/standings.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import logging
 
@@ -10,8 +10,3 @@ logger = logging.getLogger("worker.jobs.standings")
 @dramatiq.actor(max_retries=3)
 def recompute_standings(league_id: str, season_id: str | None) -> None:
     logger.info("Recompute standings job queued (league=%s, season=%s)", league_id, season_id)
-
-
-@dramatiq.actor(max_retries=3)
-def announce_results(league_id: str, event_id: str) -> None:
-    logger.info("Announce results job queued (league=%s, event=%s)", league_id, event_id)

--- a/worker/main.py
+++ b/worker/main.py
@@ -1,4 +1,4 @@
-"""Dramatiq worker entrypoint for GridBoss."""
+﻿"""Dramatiq worker entrypoint for GridBoss."""
 
 from __future__ import annotations
 
@@ -46,7 +46,7 @@ def main() -> None:
     dramatiq.set_broker(broker)
 
     # Import actors so Dramatiq registers them with the broker.
-    from worker.jobs import announce_results, heartbeat, recompute_standings  # noqa: F401  # pylint: disable=unused-import
+    from worker.jobs import announce_results, heartbeat, recompute_standings, send_test_message  # noqa: F401  # pylint: disable=unused-import
 
     worker = Worker(broker, worker_threads=config.worker_threads, worker_name=config.worker_name)
 
@@ -70,3 +70,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -1,1 +1,3 @@
-dramatiq[redis]==1.15.0
+﻿dramatiq[redis]==1.15.0
+httpx==0.28.1
+

--- a/worker/services/__init__.py
+++ b/worker/services/__init__.py
@@ -1,0 +1,1 @@
+﻿"Discord-facing helpers."

--- a/worker/services/discord.py
+++ b/worker/services/discord.py
@@ -1,0 +1,130 @@
+﻿from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import httpx
+
+logger = logging.getLogger("worker.discord")
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+
+
+class DiscordRateLimitError(RuntimeError):
+    """Raised when Discord responds with a rate limit."""
+
+
+class DiscordPermissionError(RuntimeError):
+    """Raised when the bot lacks permission to post to the configured channel."""
+
+
+class DiscordConfigurationError(RuntimeError):
+    """Raised when the bot is missing required configuration."""
+
+
+@dataclass(frozen=True)
+class DiscordMessage:
+    content: str | None = None
+    embeds: list[dict[str, Any]] | None = None
+
+
+class DiscordNotifier:
+    """Thin HTTP client wrapper for posting messages to Discord channels."""
+
+    def __init__(self, bot_token: str, *, timeout: float = 10.0) -> None:
+        if not bot_token:
+            raise DiscordConfigurationError("DISCORD_BOT_TOKEN is not configured")
+        self._bot_token = bot_token
+        self._timeout = timeout
+
+    def send(self, channel_id: str, message: DiscordMessage) -> None:
+        payload: dict[str, Any] = {}
+        if message.content:
+            payload["content"] = message.content
+        if message.embeds:
+            payload["embeds"] = message.embeds
+
+        headers = {
+            "Authorization": f"Bot {self._bot_token}",
+            "Content-Type": "application/json",
+        }
+
+        url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
+        with httpx.Client(timeout=self._timeout) as client:
+            response = client.post(url, headers=headers, json=payload)
+
+        if response.status_code == 429:
+            retry_after = response.headers.get("Retry-After") or response.json().get("retry_after")
+            logger.warning("Discord rate limit encountered", extra={"channel_id": channel_id, "retry_after": retry_after})
+            raise DiscordRateLimitError(f"Rate limited posting to channel {channel_id}")
+
+        if response.status_code in {401, 403, 404}:
+            logger.error(
+                "Discord permission failure",
+                extra={"channel_id": channel_id, "payload": _safe_json(payload), "status": response.status_code},
+            )
+            raise DiscordPermissionError(f"Bot lacks permission for channel {channel_id}")
+
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - unexpected HTTP errors
+            logger.error(
+                "Discord API error",
+                extra={"channel_id": channel_id, "status": response.status_code, "body": response.text},
+            )
+            raise DiscordPermissionError("Discord API returned an error") from exc
+
+
+def _safe_json(payload: dict[str, Any]) -> str:
+    try:
+        return json.dumps(payload)
+    except TypeError:  # pragma: no cover - payload should be serialisable
+        return "<unserializable payload>"
+
+
+def create_notifier_from_env() -> DiscordNotifier:
+    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    return DiscordNotifier(token)
+
+
+def build_results_embed(
+    *,
+    event_name: str,
+    league_name: str,
+    season_name: str | None,
+    results: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    lines = []
+    for index, item in enumerate(results, start=1):
+        podium_emoji = {1: "🥇", 2: "🥈", 3: "🥉"}.get(index, "•")
+        driver_name = item.get("driver")
+        points = item.get("points", 0)
+        status = item.get("status", "FINISHED")
+        line = f"{podium_emoji} **{driver_name}** — {points} pts ({status})"
+        lines.append(line)
+
+    description = "\n".join(lines) if lines else "No classified finishers."
+
+    embed = {
+        "title": f"{event_name} — Results",
+        "description": description,
+        "color": 0x5865F2,  # Discord blurple
+        "footer": {
+            "text": f"League: {league_name}" + (f" • Season: {season_name}" if season_name else "")
+        },
+    }
+    return embed
+
+
+__all__ = [
+    "DiscordNotifier",
+    "DiscordMessage",
+    "DiscordRateLimitError",
+    "DiscordPermissionError",
+    "DiscordConfigurationError",
+    "create_notifier_from_env",
+    "build_results_embed",
+]


### PR DESCRIPTION
Merge summary:

Ship bot config/service/entrypoint plus slash commands that link/test integrations while reusing worker actors.
Replace placeholder Discord jobs with full notifier + embed handling, permission/rate-limit recovery, and updated worker wiring.
Add comprehensive bot/worker tests, queue Discord announcements from results, and mark PBI-014 complete.