### PR TITLE
feat: add Stripe webhook handling and plan sync

### DIFF
--- a/api/app/core/settings.py
+++ b/api/app/core/settings.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from functools import lru_cache
 from typing import Literal
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     stripe_secret_key: str = Field(default="", alias="STRIPE_SECRET_KEY")
     stripe_price_pro: str = Field(default="", alias="STRIPE_PRICE_PRO")
     stripe_price_elite: str = Field(default="", alias="STRIPE_PRICE_ELITE")
+    stripe_webhook_secret: str = Field(default="", alias="STRIPE_WEBHOOK_SECRET")
 
     discord_client_id: str = Field(alias="DISCORD_CLIENT_ID")
     discord_client_secret: str = Field(alias="DISCORD_CLIENT_SECRET")

--- a/api/app/db/migrations/versions/20250924_0003_stripe_events.py
+++ b/api/app/db/migrations/versions/20250924_0003_stripe_events.py
@@ -1,0 +1,35 @@
+﻿"""create stripe events table"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20250924_0003_stripe_events"
+down_revision: str | None = "20250921_0002_add_soft_delete"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stripe_events",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("event_id", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_stripe_events"),
+        sa.UniqueConstraint("event_id", name="uq_stripe_events_event_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("stripe_events")

--- a/api/app/db/models.py
+++ b/api/app/db/models.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import enum
 from datetime import datetime
@@ -378,6 +378,21 @@ class Subscription(Base):
 
     billing_account: Mapped[BillingAccount] = relationship(back_populates="subscriptions")
 
+
+
+class StripeEvent(Base):
+    __tablename__ = "stripe_events"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    event_id: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
 
 class AuditLog(Base):
     __tablename__ = "audit_logs"

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -19,6 +19,7 @@ from app.routes import (
     results,
     seasons,
     standings,
+    webhooks,
     teams,
 )
 
@@ -47,6 +48,7 @@ app.include_router(discord.router)
 app.include_router(standings.router)
 app.include_router(seasons.router)
 app.include_router(points.router)
+app.include_router(webhooks.router)
 app.include_router(teams.router)
 
 

--- a/api/app/routes/__init__.py
+++ b/api/app/routes/__init__.py
@@ -12,6 +12,7 @@ from . import (
     results,
     seasons,
     standings,
+    webhooks,
     teams,
 )
 
@@ -27,5 +28,6 @@ __all__ = [
     "results",
     "seasons",
     "standings",
+    "webhooks",
     "teams",
 ]

--- a/api/app/routes/webhooks.py
+++ b/api/app/routes/webhooks.py
@@ -1,0 +1,334 @@
+﻿from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Annotated
+from uuid import UUID
+
+import stripe
+
+from fastapi import APIRouter, Depends, Header, Request, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import api_error
+from app.core.settings import Settings, get_settings
+from app.db.models import BillingAccount, League, StripeEvent, Subscription
+from app.db.session import get_session
+
+try:
+    from worker.jobs import stripe as stripe_jobs
+except Exception:  # pragma: no cover - worker optional during testing
+    stripe_jobs = None  # type: ignore
+
+router = APIRouter(tags=["webhooks"])
+
+SessionDep = Annotated[Session, Depends(get_session)]
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+PLAN_DRIVER_LIMITS = {"FREE": 20, "PRO": 100, "ELITE": 9999}
+
+
+def _map_price_to_plan(price_id: str, settings: Settings) -> str | None:
+    mapping = {
+        settings.stripe_price_pro: "PRO",
+        settings.stripe_price_elite: "ELITE",
+    }
+    return mapping.get(price_id)
+
+
+def _update_leagues_for_plan(session: Session, billing_account: BillingAccount, plan: str) -> None:
+    driver_limit = PLAN_DRIVER_LIMITS.get(plan, PLAN_DRIVER_LIMITS["FREE"])
+    billing_account.plan = plan
+    leagues = session.execute(
+        select(League).where(League.owner_id == billing_account.owner_user_id)
+    ).scalars().all()
+    for league in leagues:
+        league.plan = plan
+        league.driver_limit = driver_limit
+
+
+def _ensure_subscription(
+    session: Session,
+    *,
+    billing_account: BillingAccount,
+    subscription_id: str,
+) -> Subscription:
+    subscription = (
+        session.execute(
+            select(Subscription).where(Subscription.stripe_subscription_id == subscription_id)
+        )
+        .scalars()
+        .first()
+    )
+    if subscription is None:
+        subscription = Subscription(
+            billing_account_id=billing_account.id,
+            stripe_subscription_id=subscription_id,
+            plan=billing_account.plan,
+            status="active",
+        )
+        session.add(subscription)
+    return subscription
+
+
+def _record_processed_event(session: Session, event_id: str) -> StripeEvent:
+    event_row = StripeEvent(event_id=event_id)
+    session.add(event_row)
+    session.flush()
+    return event_row
+
+
+def _parse_timestamp(value: int | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromtimestamp(value, tz=UTC)
+
+
+def _handle_checkout_completed(
+    session: Session,
+    *,
+    payload: dict[str, object],
+    settings: Settings,
+) -> None:
+    data_object = payload.get("data", {}).get("object", {})  # type: ignore[assignment]
+    customer_id = data_object.get("customer") if isinstance(data_object, dict) else None
+    subscription_id = data_object.get("subscription") if isinstance(data_object, dict) else None
+    metadata = data_object.get("metadata") if isinstance(data_object, dict) else {}
+
+    if not isinstance(customer_id, str):
+        return
+
+    billing_account = (
+        session.execute(
+            select(BillingAccount).where(BillingAccount.stripe_customer_id == customer_id)
+        )
+        .scalars()
+        .first()
+    )
+    if billing_account is None:
+        return
+
+    requested_plan = None
+    if isinstance(metadata, dict):
+        plan_value = metadata.get("plan")
+        if isinstance(plan_value, str):
+            requested_plan = plan_value.upper()
+
+    if requested_plan not in {"PRO", "ELITE"}:
+        price_id = metadata.get("price_id") if isinstance(metadata, dict) else None
+        if isinstance(price_id, str):
+            requested_plan = _map_price_to_plan(price_id, settings)
+
+    if requested_plan:
+        _update_leagues_for_plan(session, billing_account, requested_plan)
+
+    if isinstance(subscription_id, str):
+        subscription = _ensure_subscription(
+            session,
+            billing_account=billing_account,
+            subscription_id=subscription_id,
+        )
+        if requested_plan:
+            subscription.plan = requested_plan
+        subscription.status = "active"
+
+
+def _extract_price_plan(data: dict[str, object], settings: Settings) -> str | None:
+    plan = None
+    items = data.get("items") if isinstance(data, dict) else None
+    if isinstance(items, dict):
+        data_items = items.get("data")
+        if isinstance(data_items, list) and data_items:
+            first = data_items[0]
+            if isinstance(first, dict):
+                price = first.get("price")
+                if isinstance(price, dict):
+                    price_id = price.get("id")
+                    if isinstance(price_id, str):
+                        plan = _map_price_to_plan(price_id, settings)
+    if plan is None:
+        metadata = data.get("metadata") if isinstance(data, dict) else None
+        if isinstance(metadata, dict):
+            plan_value = metadata.get("plan")
+            if isinstance(plan_value, str):
+                plan = plan_value.upper()
+    return plan
+
+
+def _handle_subscription_update(
+    session: Session,
+    *,
+    payload: dict[str, object],
+    settings: Settings,
+) -> None:
+    data = payload.get("data", {}).get("object", {})  # type: ignore[assignment]
+    if not isinstance(data, dict):
+        return
+
+    customer_id = data.get("customer")
+    subscription_id = data.get("id")
+    status = data.get("status")
+    current_period_end = data.get("current_period_end")
+
+    if not isinstance(customer_id, str) or not isinstance(subscription_id, str):
+        return
+
+    billing_account = (
+        session.execute(
+            select(BillingAccount).where(BillingAccount.stripe_customer_id == customer_id)
+        )
+        .scalars()
+        .first()
+    )
+    if billing_account is None:
+        return
+
+    subscription = _ensure_subscription(
+        session,
+        billing_account=billing_account,
+        subscription_id=subscription_id,
+    )
+
+    plan = _extract_price_plan(data, settings)
+    if plan:
+        subscription.plan = plan
+        _update_leagues_for_plan(session, billing_account, plan)
+
+    if isinstance(status, str):
+        subscription.status = status
+    billing_account.current_period_end = _parse_timestamp(current_period_end if isinstance(current_period_end, int) else None)
+
+    if stripe_jobs is not None:
+        try:
+            stripe_jobs.sync_plan_from_stripe.send(customer_id)
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+
+def _handle_subscription_deleted(session: Session, *, payload: dict[str, object], settings: Settings) -> None:
+    data = payload.get("data", {}).get("object", {})  # type: ignore[assignment]
+    if not isinstance(data, dict):
+        return
+
+    customer_id = data.get("customer")
+    subscription_id = data.get("id")
+    if not isinstance(customer_id, str) or not isinstance(subscription_id, str):
+        return
+
+    billing_account = (
+        session.execute(
+            select(BillingAccount).where(BillingAccount.stripe_customer_id == customer_id)
+        )
+        .scalars()
+        .first()
+    )
+    if billing_account is None:
+        return
+
+    subscription = (
+        session.execute(
+            select(Subscription).where(Subscription.stripe_subscription_id == subscription_id)
+        )
+        .scalars()
+        .first()
+    )
+    if subscription is not None:
+        subscription.status = "canceled"
+
+    _update_leagues_for_plan(session, billing_account, "FREE")
+
+
+def _handle_invoice_payment_failed(session: Session, *, payload: dict[str, object], settings: Settings) -> None:
+    data = payload.get("data", {}).get("object", {})  # type: ignore[assignment]
+    if not isinstance(data, dict):
+        return
+
+    customer_id = data.get("customer")
+    subscription_id = data.get("subscription")
+    if not isinstance(customer_id, str) or not isinstance(subscription_id, str):
+        return
+
+    subscription = (
+        session.execute(
+            select(Subscription).where(Subscription.stripe_subscription_id == subscription_id)
+        )
+        .scalars()
+        .first()
+    )
+    if subscription is not None:
+        subscription.status = "past_due"
+
+
+EVENT_HANDLERS = {
+    "checkout.session.completed": _handle_checkout_completed,
+    "customer.subscription.updated": _handle_subscription_update,
+    "customer.subscription.deleted": _handle_subscription_deleted,
+    "invoice.payment_failed": _handle_invoice_payment_failed,
+}
+
+
+@router.post("/webhooks/stripe", status_code=status.HTTP_200_OK)
+async def stripe_webhook(
+    request: Request,
+    session: SessionDep,
+    settings: SettingsDep,
+    stripe_signature: str | None = Header(default=None, alias="Stripe-Signature"),
+) -> dict[str, str]:
+    if not settings.stripe_webhook_secret:
+        raise api_error(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            code="BILLING_CONFIG",
+            message="Stripe webhook secret not configured",
+        )
+    if stripe_signature is None:
+        raise api_error(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code="MISSING_SIGNATURE",
+            message="Stripe signature header missing",
+        )
+
+    payload_bytes = await request.body()
+    payload_str = payload_bytes.decode("utf-8")
+
+    try:
+        event = stripe.Webhook.construct_event(  # type: ignore[attr-defined]
+            payload_str,
+            stripe_signature,
+            settings.stripe_webhook_secret,
+        )
+    except stripe.error.SignatureVerificationError:  # type: ignore[attr-defined]
+        raise api_error(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code="INVALID_SIGNATURE",
+            message="Invalid Stripe signature",
+        )
+
+    event_id = event.get("id") if isinstance(event, dict) else None
+    event_type = event.get("type") if isinstance(event, dict) else None
+    if not isinstance(event_id, str) or not isinstance(event_type, str):
+        raise api_error(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code="INVALID_EVENT",
+            message="Stripe event missing id or type",
+        )
+
+    existing = (
+        session.execute(select(StripeEvent).where(StripeEvent.event_id == event_id))
+        .scalars()
+        .first()
+    )
+    if existing is not None:
+        return {"status": "ignored"}
+
+    try:
+        recorded = _record_processed_event(session, event_id)
+        handler = EVENT_HANDLERS.get(event_type)
+        if handler is not None:
+            handler(session, payload=event, settings=settings)
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+
+    return {"status": "processed"}

--- a/api/tests/test_webhooks.py
+++ b/api/tests/test_webhooks.py
@@ -1,0 +1,353 @@
+﻿from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.settings import Settings, get_settings
+from app.db import Base
+from app.db.models import (
+    BillingAccount,
+    League,
+    LeagueRole,
+    Membership,
+    StripeEvent,
+    Subscription,
+    User,
+)
+from app.db.session import get_session
+from app.main import app
+
+SQLALCHEMY_DATABASE_URL = "sqlite+pysqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    future=True,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+)
+
+for table in Base.metadata.sorted_tables:
+    for column in table.c:
+        default = getattr(column, "server_default", None)
+        if default is not None and hasattr(default, "arg") and "gen_random_uuid" in str(default.arg):
+            column.server_default = None
+
+Base.metadata.create_all(bind=engine)
+
+
+def reset_database() -> None:
+    with engine.begin() as connection:
+        for table in reversed(Base.metadata.sorted_tables):
+            connection.execute(table.delete())
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_database()
+    get_settings.cache_clear()
+    settings = Settings(
+        APP_ENV="test",
+        APP_URL="http://localhost:5173",
+        API_URL="http://localhost:8000",
+        DISCORD_CLIENT_ID="client",
+        DISCORD_CLIENT_SECRET="secret",
+        DISCORD_REDIRECT_URI="http://localhost:8000/auth/discord/callback",
+        JWT_SECRET="secret",
+        JWT_ACCESS_TTL_MIN=15,
+        JWT_REFRESH_TTL_DAYS=14,
+        CORS_ORIGINS="http://localhost:5173",
+        REDIS_URL="redis://localhost:6379/0",
+        STRIPE_SECRET_KEY="sk_test",
+        STRIPE_PRICE_PRO="price_pro",
+        STRIPE_PRICE_ELITE="price_elite",
+        STRIPE_WEBHOOK_SECRET="test-secret",
+    )
+
+    def get_test_session() -> Session:
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.dependency_overrides[get_session] = get_test_session
+
+    yield
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def sync_spy(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    import worker.jobs.stripe as stripe_jobs
+
+    calls: list[str] = []
+    monkeypatch.setattr(stripe_jobs.sync_plan_from_stripe, "send", lambda customer_id: calls.append(customer_id))
+    return calls
+
+
+def create_user(session: Session) -> User:
+    user = User(discord_id=str(uuid4()), discord_username="user", email=f"{uuid4().hex}@example.com")
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def create_owner(session: Session) -> tuple[User, League]:
+    owner = create_user(session)
+    league = League(name="League", slug=f"league-{uuid4().hex[:8]}", owner_id=owner.id)
+    session.add(league)
+    session.commit()
+    session.refresh(league)
+    membership = Membership(league_id=league.id, user_id=owner.id, role=LeagueRole.OWNER)
+    session.add(membership)
+    session.commit()
+    return owner, league
+
+
+def make_headers() -> dict[str, str]:
+    return {
+        "Stripe-Signature": "test-secret",
+        "Content-Type": "application/json",
+    }
+
+
+def test_missing_signature(client: TestClient) -> None:
+    response = client.post("/webhooks/stripe", content="{}")
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "MISSING_SIGNATURE"
+
+
+def test_invalid_signature(client: TestClient) -> None:
+    response = client.post(
+        "/webhooks/stripe",
+        headers={"Stripe-Signature": "invalid"},
+        content="{}",
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_SIGNATURE"
+
+
+def test_checkout_completed_creates_subscription(client: TestClient) -> None:
+    session = TestingSessionLocal()
+    owner, _ = create_owner(session)
+    billing = BillingAccount(owner_user_id=owner.id, plan="FREE", stripe_customer_id="cus_123")
+    session.add(billing)
+    session.commit()
+
+    event = {
+        "id": "evt_checkout",
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "customer": "cus_123",
+                "subscription": "sub_123",
+                "metadata": {"plan": "PRO"},
+            }
+        },
+    }
+
+    response = client.post(
+        "/webhooks/stripe",
+        headers=make_headers(),
+        content=json.dumps(event),
+    )
+
+    assert response.status_code == 200
+    session.close()
+    verify = TestingSessionLocal()
+    stripe_event = verify.execute(select(StripeEvent).where(StripeEvent.event_id == "evt_checkout")).scalar_one()
+    assert stripe_event is not None
+    subscription = verify.execute(select(Subscription).where(Subscription.stripe_subscription_id == "sub_123")).scalar_one()
+    assert subscription.plan == "PRO"
+    billing = verify.execute(select(BillingAccount).where(BillingAccount.owner_user_id == owner.id)).scalar_one()
+    assert billing.plan == "PRO"
+    league = verify.execute(select(League).where(League.owner_id == owner.id)).scalar_one()
+    assert league.plan == "PRO"
+    verify.close()
+
+
+def test_subscription_updated_updates_plan_and_enqueues_sync(client: TestClient, sync_spy: list[str]) -> None:
+    session = TestingSessionLocal()
+    owner, _ = create_owner(session)
+    billing = BillingAccount(owner_user_id=owner.id, plan="PRO", stripe_customer_id="cus_456")
+    session.add(billing)
+    session.commit()
+    session.refresh(billing)
+    subscription = Subscription(
+        billing_account_id=billing.id,
+        stripe_subscription_id="sub_456",
+        plan="PRO",
+        status="active",
+    )
+    session.add(subscription)
+    session.commit()
+
+    current_period_end = int(datetime.now(tz=timezone.utc).timestamp())
+    event = {
+        "id": "evt_update",
+        "type": "customer.subscription.updated",
+        "data": {
+            "object": {
+                "id": "sub_456",
+                "customer": "cus_456",
+                "status": "active",
+                "current_period_end": current_period_end,
+                "items": {
+                    "data": [
+                        {
+                            "price": {"id": "price_elite"},
+                        }
+                    ]
+                },
+            }
+        },
+    }
+
+    response = client.post(
+        "/webhooks/stripe",
+        headers=make_headers(),
+        content=json.dumps(event),
+    )
+
+    assert response.status_code == 200
+    session.close()
+    verify = TestingSessionLocal()
+    subscription = verify.execute(select(Subscription).where(Subscription.stripe_subscription_id == "sub_456")).scalar_one()
+    assert subscription.plan == "ELITE"
+    assert subscription.status == "active"
+    billing = verify.execute(select(BillingAccount).where(BillingAccount.owner_user_id == owner.id)).scalar_one()
+    assert billing.plan == "ELITE"
+    league = verify.execute(select(League).where(League.owner_id == owner.id)).scalar_one()
+    assert league.driver_limit == 9999
+    stored_end = billing.current_period_end
+    assert stored_end is not None
+    if stored_end.tzinfo is None:
+        stored_end = stored_end.replace(tzinfo=timezone.utc)
+    assert int(stored_end.timestamp()) == current_period_end
+    assert sync_spy == ["cus_456"]
+    verify.close()
+
+
+def test_subscription_deleted_sets_free(client: TestClient) -> None:
+    session = TestingSessionLocal()
+    owner, _ = create_owner(session)
+    billing = BillingAccount(owner_user_id=owner.id, plan="PRO", stripe_customer_id="cus_789")
+    session.add(billing)
+    session.commit()
+    session.refresh(billing)
+    subscription = Subscription(
+        billing_account_id=billing.id,
+        stripe_subscription_id="sub_789",
+        plan="PRO",
+        status="active",
+    )
+    session.add(subscription)
+    session.commit()
+
+    event = {
+        "id": "evt_deleted",
+        "type": "customer.subscription.deleted",
+        "data": {"object": {"id": "sub_789", "customer": "cus_789"}},
+    }
+
+    response = client.post(
+        "/webhooks/stripe",
+        headers=make_headers(),
+        content=json.dumps(event),
+    )
+
+    assert response.status_code == 200
+    session.close()
+    verify = TestingSessionLocal()
+    subscription = verify.execute(select(Subscription).where(Subscription.stripe_subscription_id == "sub_789")).scalar_one()
+    assert subscription.status == "canceled"
+    billing = verify.execute(select(BillingAccount).where(BillingAccount.owner_user_id == owner.id)).scalar_one()
+    assert billing.plan == "FREE"
+    league = verify.execute(select(League).where(League.owner_id == owner.id)).scalar_one()
+    assert league.driver_limit == 20
+    verify.close()
+
+
+def test_invoice_payment_failed_marks_past_due(client: TestClient) -> None:
+    session = TestingSessionLocal()
+    owner, _ = create_owner(session)
+    billing = BillingAccount(owner_user_id=owner.id, plan="PRO", stripe_customer_id="cus_inv")
+    session.add(billing)
+    session.commit()
+    session.refresh(billing)
+    subscription = Subscription(
+        billing_account_id=billing.id,
+        stripe_subscription_id="sub_inv",
+        plan="PRO",
+        status="active",
+    )
+    session.add(subscription)
+    session.commit()
+
+    event = {
+        "id": "evt_invoice",
+        "type": "invoice.payment_failed",
+        "data": {"object": {"subscription": "sub_inv", "customer": "cus_inv"}},
+    }
+
+    response = client.post(
+        "/webhooks/stripe",
+        headers=make_headers(),
+        content=json.dumps(event),
+    )
+
+    assert response.status_code == 200
+    session.close()
+    verify = TestingSessionLocal()
+    subscription = verify.execute(select(Subscription).where(Subscription.stripe_subscription_id == "sub_inv")).scalar_one()
+    assert subscription.status == "past_due"
+    verify.close()
+
+
+def test_idempotent_event_ignored(client: TestClient) -> None:
+    session = TestingSessionLocal()
+    owner, _ = create_owner(session)
+    billing = BillingAccount(owner_user_id=owner.id, plan="PRO", stripe_customer_id="cus_dupe")
+    session.add(billing)
+    session.commit()
+
+    event = {
+        "id": "evt_dupe",
+        "type": "checkout.session.completed",
+        "data": {"object": {"customer": "cus_dupe", "subscription": "sub_dupe", "metadata": {"plan": "PRO"}}},
+    }
+
+    payload = json.dumps(event)
+    headers = make_headers()
+
+    first = client.post("/webhooks/stripe", headers=headers, content=payload)
+    second = client.post("/webhooks/stripe", headers=headers, content=payload)
+
+    assert first.status_code == 200
+    assert first.json()["status"] == "processed"
+    assert second.status_code == 200
+    assert second.json()["status"] == "ignored"
+    events = session.execute(select(StripeEvent).where(StripeEvent.event_id == "evt_dupe")).scalars().all()
+    assert len(events) == 1
+    session.close()

--- a/worker/jobs/__init__.py
+++ b/worker/jobs/__init__.py
@@ -3,10 +3,12 @@
 from .discord import announce_results, send_test_message
 from .heartbeat import heartbeat
 from .standings import recompute_standings
+from .stripe import sync_plan_from_stripe
 
 __all__ = [
+    "announce_results",
     "heartbeat",
     "recompute_standings",
-    "announce_results",
     "send_test_message",
+    "sync_plan_from_stripe",
 ]

--- a/worker/jobs/stripe.py
+++ b/worker/jobs/stripe.py
@@ -1,0 +1,12 @@
+﻿from __future__ import annotations
+
+import logging
+
+import dramatiq
+
+logger = logging.getLogger("worker.jobs.stripe")
+
+
+@dramatiq.actor(max_retries=3)
+def sync_plan_from_stripe(customer_id: str) -> None:
+    logger.info("Sync plan from Stripe queued (customer=%s)", customer_id)

--- a/worker/main.py
+++ b/worker/main.py
@@ -46,7 +46,7 @@ def main() -> None:
     dramatiq.set_broker(broker)
 
     # Import actors so Dramatiq registers them with the broker.
-    from worker.jobs import announce_results, heartbeat, recompute_standings, send_test_message  # noqa: F401  # pylint: disable=unused-import
+    from worker.jobs import announce_results, heartbeat, recompute_standings, send_test_message, sync_plan_from_stripe  # noqa: F401  # pylint: disable=unused-import
 
     worker = Worker(broker, worker_threads=config.worker_threads, worker_name=config.worker_name)
 
@@ -70,4 +70,5 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
 


### PR DESCRIPTION
## PBI-016 - Stripe Webhooks and Plan Sync
Summary: Process Stripe webhook events to align subscription state and grace periods.
Scope: Backend
Acceptance Criteria:

POST /webhooks/stripe verifies signature using STRIPE_WEBHOOK_SECRET and handles checkout.session.completed, customer.subscription.updated, customer.subscription.deleted, and invoice.payment_failed.
Webhook handler updates billing_accounts and subscriptions tables, sets current_period_end, and schedules sync_plan_from_stripe job when needed.
Idempotency for Stripe events stored to prevent double processing with tests covering success, replay, and signature failure.
Dependencies: PBI-015, PBI-010
Branch: pbi/016-stripe-webhooks