### PR TITLE
feat: enforce plan entitlements with grace support

### DIFF
--- a/api/app/db/migrations/versions/20250921_0001_initial_schema.py
+++ b/api/app/db/migrations/versions/20250921_0001_initial_schema.py
@@ -12,7 +12,6 @@ depends_on = None
 
 def upgrade() -> None:
     league_role = sa.Enum("OWNER", "ADMIN", "STEWARD", "DRIVER", name="league_role")
-    league_role.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
         "users",
@@ -68,7 +67,7 @@ def upgrade() -> None:
         ),
         sa.Column("league_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("role", sa.Enum(name="league_role"), nullable=False),
+        sa.Column("role", league_role, nullable=False),
         sa.ForeignKeyConstraint(
             ["league_id"],
             ["leagues.id"],

--- a/api/app/db/migrations/versions/20250924_0003_stripe_events.py
+++ b/api/app/db/migrations/versions/20250924_0003_stripe_events.py
@@ -1,4 +1,4 @@
-﻿"""create stripe events table"""
+"""create stripe events table"""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "20250924_0003_stripe_events"
-down_revision: str | None = "20250921_0002_add_soft_delete"
+down_revision: str | None = "20250921_0002"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 

--- a/api/app/db/migrations/versions/20250924_0004_plan_grace.py
+++ b/api/app/db/migrations/versions/20250924_0004_plan_grace.py
@@ -1,0 +1,27 @@
+"""add plan grace columns"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20250924_0004_plan_grace"
+down_revision: str | None = "20250924_0003_stripe_events"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("billing_accounts", sa.Column("plan_grace_plan", sa.String(), nullable=True))
+    op.add_column(
+        "billing_accounts",
+        sa.Column("plan_grace_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("billing_accounts", "plan_grace_expires_at")
+    op.drop_column("billing_accounts", "plan_grace_plan")

--- a/api/app/db/models.py
+++ b/api/app/db/models.py
@@ -350,6 +350,8 @@ class BillingAccount(Base):
     stripe_customer_id: Mapped[str | None] = mapped_column(String, unique=True)
     plan: Mapped[str] = mapped_column(String, nullable=False, server_default=text("'FREE'"))
     current_period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    plan_grace_plan: Mapped[str | None] = mapped_column(String)
+    plan_grace_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     owner: Mapped[User] = relationship(back_populates="billing_account")
     subscriptions: Mapped[list[Subscription]] = relationship(back_populates="billing_account")

--- a/api/app/dependencies/plan.py
+++ b/api/app/dependencies/plan.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from functools import wraps
+from inspect import iscoroutinefunction
+from typing import Any, Callable
+from uuid import UUID
+
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.core.errors import api_error
+from app.db.models import League
+from app.services.plan import (
+    effective_plan,
+    get_billing_account_for_owner,
+    is_plan_sufficient,
+)
+
+
+def _resolve_league(session: Session, kwargs: dict[str, Any]) -> League:
+    league = kwargs.get("league")
+    if isinstance(league, League):
+        return league
+
+    league_id = kwargs.get("league_id")
+    if league_id is None:
+        raise RuntimeError("requires_plan decorator expects 'league' or 'league_id' arguments")
+
+    if not isinstance(league_id, UUID):
+        try:
+            league_id = UUID(str(league_id))
+        except (TypeError, ValueError) as exc:
+            raise api_error(
+                status_code=status.HTTP_404_NOT_FOUND,
+                code="LEAGUE_NOT_FOUND",
+                message="League not found",
+            ) from exc
+
+    league_obj = session.get(League, league_id)
+    if league_obj is None or league_obj.is_deleted:
+        raise api_error(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="LEAGUE_NOT_FOUND",
+            message="League not found",
+        )
+
+    return league_obj
+
+
+def _ensure_plan_access(
+    *,
+    session: Session,
+    league: League,
+    required_plan: str,
+    message: str | None,
+) -> None:
+    billing_account = get_billing_account_for_owner(session, league.owner_id)
+    current_plan = effective_plan(league.plan, billing_account)
+    if not is_plan_sufficient(current_plan, required_plan):
+        detail = message or f"This action requires the {required_plan.title()} plan"
+        raise api_error(
+            status_code=status.HTTP_403_FORBIDDEN,
+            code="PLAN_LIMIT",
+            message=detail,
+        )
+
+
+def requires_plan(required_plan: str, *, message: str | None = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    normalized_required = required_plan.upper()
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        if iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                session = kwargs.get("session")
+                if session is None:
+                    raise RuntimeError("requires_plan decorator expects a 'session' argument")
+                league = _resolve_league(session, kwargs)
+                _ensure_plan_access(
+                    session=session,
+                    league=league,
+                    required_plan=normalized_required,
+                    message=message,
+                )
+                return await func(*args, **kwargs)
+
+            async_wrapper.__globals__.update(func.__globals__)
+            return async_wrapper
+
+        @wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            session = kwargs.get("session")
+            if session is None:
+                raise RuntimeError("requires_plan decorator expects a 'session' argument")
+            league = _resolve_league(session, kwargs)
+            _ensure_plan_access(
+                session=session,
+                league=league,
+                required_plan=normalized_required,
+                message=message,
+            )
+            return func(*args, **kwargs)
+
+        sync_wrapper.__globals__.update(func.__globals__)
+        return sync_wrapper
+
+    return decorator
+
+
+__all__ = ["requires_plan"]

--- a/api/app/services/plan.py
+++ b/api/app/services/plan.py
@@ -1,0 +1,102 @@
+from datetime import UTC, datetime, timedelta
+from typing import Final
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models import BillingAccount, League
+
+PLAN_DRIVER_LIMITS: Final[dict[str, int]] = {"FREE": 20, "PRO": 100, "ELITE": 9999}
+_PLAN_ORDER: Final[tuple[str, ...]] = ("FREE", "PRO", "ELITE")
+DEFAULT_PLAN: Final[str] = "FREE"
+GRACE_PERIOD_DAYS: Final[int] = 7
+
+def normalize_plan(plan: str | None) -> str:
+    if not plan:
+        return DEFAULT_PLAN
+    return plan.upper()
+
+def _plan_rank(plan: str | None) -> int:
+    normalized = normalize_plan(plan)
+    try:
+        return _PLAN_ORDER.index(normalized)
+    except ValueError:
+        return _PLAN_ORDER.index(DEFAULT_PLAN)
+
+def is_plan_sufficient(current: str | None, required: str) -> bool:
+    return _plan_rank(current) >= _plan_rank(required)
+
+def _max_plan(*plans: str | None) -> str:
+    best = DEFAULT_PLAN
+    for plan in plans:
+        normalized = normalize_plan(plan)
+        if _plan_rank(normalized) > _plan_rank(best):
+            best = normalized
+    return best
+
+def _ensure_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+def effective_plan(
+    league_plan: str | None,
+    billing_account: BillingAccount | None,
+    *,
+    now: datetime | None = None,
+) -> str:
+    current = normalize_plan(league_plan)
+    if billing_account is not None:
+        current = _max_plan(current, billing_account.plan)
+        grace_plan = billing_account.plan_grace_plan
+        expires_at = _ensure_utc(billing_account.plan_grace_expires_at)
+        if grace_plan and expires_at:
+            reference = _ensure_utc(now) or datetime.now(UTC)
+            if expires_at > reference:
+                current = _max_plan(current, grace_plan)
+    return current
+
+def effective_driver_limit(
+    league: League,
+    billing_account: BillingAccount | None,
+    *,
+    now: datetime | None = None,
+) -> int:
+    limit = league.driver_limit
+    if billing_account is not None:
+        expires_at = _ensure_utc(billing_account.plan_grace_expires_at)
+        grace_plan = billing_account.plan_grace_plan
+        if grace_plan and expires_at:
+            reference = _ensure_utc(now) or datetime.now(UTC)
+            if expires_at > reference:
+                grace_limit = PLAN_DRIVER_LIMITS.get(
+                    normalize_plan(grace_plan), PLAN_DRIVER_LIMITS[DEFAULT_PLAN]
+                )
+                limit = max(limit, grace_limit)
+    return limit
+
+def get_billing_account_for_owner(
+    session: Session,
+    owner_id: UUID,
+) -> BillingAccount | None:
+    return (
+        session.execute(
+            select(BillingAccount).where(BillingAccount.owner_user_id == owner_id)
+        )
+        .scalars()
+        .first()
+    )
+
+__all__ = [
+    "DEFAULT_PLAN",
+    "GRACE_PERIOD_DAYS",
+    "PLAN_DRIVER_LIMITS",
+    "effective_driver_limit",
+    "effective_plan",
+    "get_billing_account_for_owner",
+    "is_plan_sufficient",
+    "normalize_plan",
+]

--- a/api/tests/test_drivers.py
+++ b/api/tests/test_drivers.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from http import HTTPStatus
 from uuid import uuid4
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -13,7 +14,7 @@ from sqlalchemy.pool import StaticPool
 
 from app.core.settings import Settings, get_settings
 from app.db import Base
-from app.db.models import Driver, League, LeagueRole, Membership, Team, User
+from app.db.models import BillingAccount, Driver, League, LeagueRole, Membership, Team, User
 from app.db.session import get_session
 from app.dependencies.auth import get_current_user
 from app.main import app
@@ -212,6 +213,63 @@ class TestDriverRoutes:
     ) -> None:
         owner = stub_user(database_session, "owner")
         league = create_league_with_owner(database_session, owner, driver_limit=1)
+
+        payload = {
+            "items": [
+                {"display_name": "Driver One"},
+                {"display_name": "Driver Two"},
+            ]
+        }
+
+        with override_user(owner):
+            response = client.post(f"/leagues/{league.id}/drivers", json=payload)
+
+        assert response.status_code == HTTPStatus.PAYMENT_REQUIRED
+        assert response.json()["error"]["code"] == "PLAN_LIMIT"
+
+    def test_bulk_create_drivers_allows_during_grace(self, client: TestClient, database_session: Session) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner, driver_limit=1)
+        league.plan = "FREE"
+        database_session.commit()
+
+        billing = BillingAccount(
+            owner_user_id=owner.id,
+            plan="FREE",
+            plan_grace_plan="PRO",
+            plan_grace_expires_at=datetime.now(timezone.utc) + timedelta(days=2),
+        )
+        database_session.add(billing)
+        database_session.commit()
+
+        payload = {
+            "items": [
+                {"display_name": "Driver One"},
+                {"display_name": "Driver Two"},
+            ]
+        }
+
+        with override_user(owner):
+            response = client.post(f"/leagues/{league.id}/drivers", json=payload)
+
+        assert response.status_code == HTTPStatus.CREATED, response.text
+        data = response.json()
+        assert len(data) == 2
+
+    def test_bulk_create_drivers_denies_after_grace(self, client: TestClient, database_session: Session) -> None:
+        owner = stub_user(database_session, "owner")
+        league = create_league_with_owner(database_session, owner, driver_limit=1)
+        league.plan = "FREE"
+        database_session.commit()
+
+        billing = BillingAccount(
+            owner_user_id=owner.id,
+            plan="FREE",
+            plan_grace_plan="PRO",
+            plan_grace_expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        database_session.add(billing)
+        database_session.commit()
 
         payload = {
             "items": [

--- a/docs/AppPBIs.md
+++ b/docs/AppPBIs.md
@@ -150,7 +150,7 @@ Acceptance Criteria:
 Dependencies: PBI-004, PBI-003
 Branch: pbi/015-stripe-checkout
 
-## PBI-016 - Stripe Webhooks and Plan Sync
+## PBI-016 - Stripe Webhooks and Plan Sync (complete)
 Summary: Process Stripe webhook events to align subscription state and grace periods.
 Scope: Backend
 Acceptance Criteria:
@@ -210,6 +210,7 @@ Acceptance Criteria:
 Dependencies: PBI-011, PBI-012
 Branch: pbi/021-seed-data
 
+## FRONTEND --------------------------------------------------------------------
 ## PBI-022 - Frontend Shell and Auth Flow
 Summary: Build React shell with routing, state, and authentication handling.
 Scope: Frontend
@@ -339,6 +340,8 @@ Acceptance Criteria:
 - Accessibility tooling integrated with CI and high severity issues resolved.
 Dependencies: PBI-028, PBI-032
 Branch: pbi/034-frontend-tests
+
+## OPS & CI -----------------------------------------------------------------------------------
 
 ## PBI-035 - CI Pipeline and Quality Gates
 Summary: Configure continuous integration workflows for linting, testing, and builds.


### PR DESCRIPTION
## Summary
- track Stripe downgrade grace periods on billing accounts and expose helpers for plan checks
- gate Discord routes and driver creation using shared @requires_plan decorator with grace-aware driver limits
- adjust webhook/billing flows plus add regression tests for grace-period behavior

## Testing
- python -m pytest
